### PR TITLE
Exposing vnet address space and subnet address range as parameters

### DIFF
--- a/src/vfxt/azuredeploy-auto.json
+++ b/src/vfxt/azuredeploy-auto.json
@@ -55,6 +55,20 @@
         "description": "The unique name used for the virtual network subnet.  If createVirtualNetwork? is set to true, you may reuse the unique name above."
       }
     },
+    "vnetAddressSpacePrefix":{
+      "type": "string",
+      "metadata": {
+        "description": "Virtual network address space prefix used when creating a virtual network with this deployment. E.g. 192.168.0.0/16"
+      },
+      "defaultValue": "192.168.0.0/16"
+    },
+    "subnetAddressRangePrefix":{
+      "type": "string",
+      "metadata": {
+        "description": "Subnet address range prefix used when creating a virtual network/subnet with this deployment. E.g. 192.168.0.0/24"
+      },
+      "defaultValue": "192.168.0.0/24"
+    },
     "useAvereBackedStorageAccount?": {
       "type": "bool",
       "defaultValue": true,
@@ -152,8 +166,8 @@
     "additionalVFXTParameters": "[parameters('additionalVFXTParameters')]",
     "controllerVMSize": "Standard_A1_v2",
     "avereCacheSizeGB": "[if(equals('Standard_D16s_v3',variables('avereInstanceType')),1024,4096)]",
-    "addressPrefix": "10.0.0.0/16",
-    "subnetPrefix": "10.0.0.0/20",
+    "addressPrefix": "[parameters('vnetAddressSpacePrefix')]",
+    "subnetPrefix": "[parameters('subnetAddressRangePrefix')]",
     "publicIPAddressName": "[concat('publicip-',variables('controllerName'))]",
     "networkSecurityGroupName": "[concat('nsg-',variables('controllerName'))]",
     "vnetID": "[resourceId(variables('virtualNetworkResourceGroup'),'Microsoft.Network/virtualNetworks',variables('virtualNetworkName'))]",


### PR DESCRIPTION
Hi Anthony,

Another PR, now to expose the vnet address space and subnet address range so deployment gets a little bit more flexible. I'm going to use this template extensively since I'm working on a whitepaper with vFXT in it.

Regards
Paulo
