### PR TITLE
use a hash code for the job

### DIFF
--- a/src/go/pkg/edasim/batch.go
+++ b/src/go/pkg/edasim/batch.go
@@ -2,6 +2,7 @@ package edasim
 
 import (
 	"fmt"
+	"hash/fnv"
 	"path"
 	"time"
 )
@@ -13,6 +14,18 @@ func GetBatchName(fullFilePath string) string {
 
 // GenerateBatchName generates a batchname based on time
 func GenerateBatchName(jobCount int) string {
+	t := time.Now()
+	uniqueStr := fmt.Sprintf("%02d-%02d-%02d-%02d%02d%02d-%d-%d", t.Year(), t.Month(), t.Day(), t.Hour(), t.Minute(), t.Second(), t.Nanosecond(), jobCount)
+
+	// generate a hashcode of the string
+	h := fnv.New32a()
+	h.Write([]byte(uniqueStr))
+
+	return fmt.Sprintf("%d", h.Sum32())
+}
+
+// GenerateBatchName2 generates a batchname based on time
+func GenerateBatchName2(jobCount int) string {
 	t := time.Now()
 	return fmt.Sprintf("job-%02d-%02d-%02d-%02d%02d%02d-%d", t.Year(), t.Month(), t.Day(), t.Hour(), t.Minute(), t.Second(), jobCount)
 }


### PR DESCRIPTION
use a hash code to avoid collisions and keep a small path name