### PR TITLE
Added command-line arguments to conftest.py

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -38,13 +38,9 @@ jobs:
     displayName: 'Install Python dependencies'
 
   - script: |
-      if [ -n "$VFXT_DEPLOY_LOCATION" ]; then
-        jq -n --arg loc $VFXT_DEPLOY_LOCATION '{ atd_obj: { location: $loc } }' > $VFXT_TEST_VARS_FILE
-        echo "LOCATION = $VFXT_DEPLOY_LOCATION"
-        cat $VFXT_TEST_VARS_FILE
-      fi
-
-      pytest --disable-pytest-warnings test/test_vfxt_template_deploy.py --doctest-modules --junitxml=junit/test-results01.xml
+      pytest --disable-pytest-warnings test/test_vfxt_template_deploy.py \
+        --location $VFXT_DEPLOY_LOCATION \
+        --doctest-modules --junitxml=junit/test-results01.xml
     displayName: 'Test template-based deployment of Avere vFXT'
     env:
       AVERE_ADMIN_PW: $(AVERE-ADMIN-PW)
@@ -59,7 +55,9 @@ jobs:
         cat $VFXT_TEST_VARS_FILE
       fi
 
-      pytest --disable-pytest-warnings test/test_vfxt_cluster_status.py -k TestVfxtClusterStatus --doctest-modules --junitxml=junit/test-results02.xml
+      pytest --disable-pytest-warnings test/test_vfxt_cluster_status.py \
+        -k TestVfxtClusterStatus \
+        --doctest-modules --junitxml=junit/test-results02.xml
     displayName: 'Test cluster status, health, etc.'
     condition: succeeded()
     env:
@@ -71,7 +69,9 @@ jobs:
       AZURE_SUBSCRIPTION_ID: $(AZURE-SUBSCRIPTION-ID)
 
   - script: |
-      pytest --disable-pytest-warnings test/test_vfxt_cluster_status.py -k TestVfxtSupport --doctest-modules --junitxml=junit/test-results03.xml
+      pytest --disable-pytest-warnings test/test_vfxt_cluster_status.py \
+        -k TestVfxtSupport \
+        --doctest-modules --junitxml=junit/test-results03.xml
 
       CONTROLLER_IP=$(jq -r .controller_ip $VFXT_TEST_VARS_FILE)
       CONTROLLER_NAME=$(jq -r .controller_name $VFXT_TEST_VARS_FILE)
@@ -105,7 +105,8 @@ jobs:
     condition: or(failed(), canceled())
 
   - script: |
-      pytest --disable-pytest-warnings test/test_vdbench.py --doctest-modules --junitxml=junit/test-results04.xml
+      pytest --disable-pytest-warnings test/test_vdbench.py \
+        --doctest-modules --junitxml=junit/test-results04.xml
     displayName: 'Test vdbench on Avere vFXT'
     condition: and(succeeded(), eq(variables['RUN_VDBENCH_STEP'], 'true'))
     env:
@@ -115,7 +116,8 @@ jobs:
       AZURE_SUBSCRIPTION_ID: $(AZURE-SUBSCRIPTION-ID)
 
   - script: |
-      pytest --disable-pytest-warnings test/test_edasim.py --doctest-modules --junitxml=junit/test-results05.xml
+      pytest --disable-pytest-warnings test/test_edasim.py \
+        --doctest-modules --junitxml=junit/test-results05.xml
     displayName: 'Test edasim on Avere vFXT'
     condition: and(succeeded(), eq(variables['RUN_EDASIM_STEP'], 'true'))
     env:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -135,7 +135,7 @@ jobs:
 
   - script: |
       az login --service-principal -u $AZURE_CLIENT_ID -p $AZURE_CLIENT_SECRET --tenant $AZURE_TENANT_ID
-      RESOURCE_GROUP=$(jq -r .atd_obj.resource_group $VFXT_TEST_VARS_FILE)
+      RESOURCE_GROUP=$(jq -r .resource_group $VFXT_TEST_VARS_FILE)
       echo "RESOURCE_GROUP: $RESOURCE_GROUP"
       az group delete --yes -n $RESOURCE_GROUP
     displayName: 'Clean up resource group'

--- a/test/arm_template_deploy.py
+++ b/test/arm_template_deploy.py
@@ -110,7 +110,7 @@ class ArmTemplateDeploy:
 
         This method returns the JSON string.
         """
-        _this = self.__dict__
+        _this = {**self.__dict__}
         _this.pop("rm_client", None)  # don't want to save these for security
         _this.pop("nm_client", None)
         _this.pop("st_client", None)

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -111,7 +111,8 @@ def scp_cli(ssh_con):
 @pytest.fixture()
 def ssh_con(test_vars):
     client = create_ssh_client(test_vars["controller_user"],
-                               test_vars["controller_ip"])
+                               test_vars["controller_ip"],
+                               key_filename=test_vars["ssh_priv_key"])
     yield client
     client.close()
 

--- a/test/lib/helpers.py
+++ b/test/lib/helpers.py
@@ -7,13 +7,14 @@ from time import sleep, time
 from paramiko import AutoAddPolicy, SSHClient
 
 
-def create_ssh_client(username, hostname, port=22, password=None):
+def create_ssh_client(username, hostname, port=22, password=None, key_filename=None):
     """Creates (and returns) an SSHClient. Auth'n is via publickey."""
     ssh_client = SSHClient()
     ssh_client.load_system_host_keys()
     ssh_client.set_missing_host_key_policy(AutoAddPolicy())
     ssh_client.connect(
-        username=username, hostname=hostname, port=port, password=password
+        username=username, hostname=hostname, port=port,
+        password=password, key_filename=key_filename
     )
     return ssh_client
 

--- a/test/test_edasim.py
+++ b/test/test_edasim.py
@@ -103,7 +103,7 @@ class TestEdasim:
 
     def test_edasim_deploy(self, test_vars):  # noqa: F811
         atd = test_vars["atd_obj"]
-        with open(os.path.expanduser(r'~/.ssh/id_rsa.pub'), 'r') as ssh_pub_f:
+        with open(test_vars["ssh_pub_key"], 'r') as ssh_pub_f:
             ssh_pub_key = ssh_pub_f.read()
         with open("{}/src/go/cmd/edasim/deploymentartifacts/template/azuredeploy.json".format(
                   os.environ["BUILD_SOURCESDIRECTORY"])) as tfile:

--- a/test/test_vdbench.py
+++ b/test/test_vdbench.py
@@ -73,6 +73,7 @@ class TestVDBench:
                     test_vars["controller_user"],
                     "127.0.0.1",
                     ssh_tunnel.local_bind_port,
+                    key_filename=test_vars["ssh_priv_key"]
                 )
                 scp_client = SCPClient(ssh_client.get_transport())
                 try:

--- a/test/test_vdbench.py
+++ b/test/test_vdbench.py
@@ -37,7 +37,7 @@ class TestVDBench:
     def test_vdbench_deploy(self, test_vars):  # noqa: F811
         log = logging.getLogger("test_vdbench_deploy")
         atd = test_vars["atd_obj"]
-        with open(os.path.expanduser(r"~/.ssh/id_rsa.pub"), "r") as ssh_pub_f:
+        with open(test_vars["ssh_pub_key"], "r") as ssh_pub_f:
             ssh_pub_key = ssh_pub_f.read()
         with open("{}/src/client/vmas/azuredeploy.json".format(
                   os.environ["BUILD_SOURCESDIRECTORY"])) as tfile:
@@ -64,7 +64,7 @@ class TestVDBench:
         with SSHTunnelForwarder(
             test_vars["controller_ip"],
             ssh_username=test_vars["controller_user"],
-            ssh_pkey=os.path.expanduser(r"~/.ssh/id_rsa"),
+            ssh_pkey=test_vars["ssh_priv_key"],
             remote_bind_address=(node_ip, 22),
         ) as ssh_tunnel:
             sleep(1)
@@ -76,8 +76,7 @@ class TestVDBench:
                 )
                 scp_client = SCPClient(ssh_client.get_transport())
                 try:
-                    scp_client.put(os.path.expanduser(r"~/.ssh/id_rsa"),
-                                   r"~/.ssh/id_rsa")
+                    scp_client.put(test_vars["ssh_priv_key"], r"~/.ssh/id_rsa")
                 finally:
                     scp_client.close()
                 commands = """

--- a/test/test_vfxt_cluster_status.py
+++ b/test/test_vfxt_cluster_status.py
@@ -111,7 +111,7 @@ class TestVfxtSupport:
             with SSHTunnelForwarder(
                 test_vars["controller_ip"],
                 ssh_username=test_vars["controller_user"],
-                ssh_pkey=os.path.expanduser(r"~/.ssh/id_rsa"),
+                ssh_pkey=test_vars["ssh_priv_key"],
                 remote_bind_address=(node_ip, 22),
             ) as ssh_tunnel:
                 sleep(1)

--- a/test/test_vfxt_template_deploy.py
+++ b/test/test_vfxt_template_deploy.py
@@ -24,7 +24,7 @@ class TestVfxtTemplateDeploy:
         with open("{}/src/vfxt/azuredeploy-auto.json".format(
                   os.environ["BUILD_SOURCESDIRECTORY"])) as tfile:
             atd.template = json.load(tfile)
-        with open(os.path.expanduser(r"~/.ssh/id_rsa.pub"), "r") as ssh_pub_f:
+        with open(test_vars["ssh_pub_key"], "r") as ssh_pub_f:
             ssh_pub_key = ssh_pub_f.read()
         atd.deploy_params = {
             "avereClusterName": atd.deploy_id + "-cluster",


### PR DESCRIPTION
Added custom command-line args to these tests so we can specify overrides on the command line more easily. More to come, but this is the first pass.

Example invocation:
`pytest test/test_vfxt_template_deploy.py --ssh_priv_key ~/.ssh/id_rsa_pipelines --ssh_pub_key ~/.ssh/id_rsa_pipelines.pub --test_vars_file TESTING.A.json --location northcentralus`
