### PR TITLE
Convert Paramiko SSH calls to Fabric to alleviate some hung thread locks

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,7 +1,7 @@
 # https://aka.ms/yaml
-# trigger:
-# - master
-# - releases/*
+trigger:
+- master
+- releases/*
 
 variables:
   VFXT_TEST_VARS_FILE: 'pipelines.json'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,7 +1,7 @@
 # https://aka.ms/yaml
-trigger:
-- master
-- releases/*
+# trigger:
+# - master
+# - releases/*
 
 variables:
   VFXT_TEST_VARS_FILE: 'pipelines.json'

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -13,7 +13,8 @@ from scp import SCPClient
 
 # local libraries
 from arm_template_deploy import ArmTemplateDeploy
-from lib.helpers import (run_ssh_command, run_ssh_commands, wait_for_op)
+from lib.helpers import (get_unused_local_port, run_ssh_command,
+                         run_ssh_commands, wait_for_op)
 
 
 # COMMAND-LINE OPTIONS ########################################################
@@ -144,7 +145,7 @@ def ssh_con(test_vars):
     # case, create an SSH tunnel before connecting to the controller.
     msg_con = "SSH connection to controller ({})".format(test_vars["controller_ip"])
     if test_vars["public_ip"] != test_vars["controller_ip"]:
-        tunnel_local_port = 2222
+        tunnel_local_port = get_unused_local_port()
         tunnel_remote_port = 22
 
         msg_con += " via jumpbox ({0}), local port {1}".format(
@@ -155,10 +156,10 @@ def ssh_con(test_vars):
                                       remote_port=tunnel_remote_port,
                                       remote_host=test_vars["controller_ip"]):
             client = Connection("127.0.0.1",
-                                user="admin",
+                                user=test_vars["controller_user"],
                                 port=tunnel_local_port,
                                 connect_kwargs={
-                                    "password": os.environ["AVERE_ADMIN_PW"]
+                                    "key_filename": test_vars["ssh_priv_key"],
                                 })
             client.open()
             yield client.client

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -118,20 +118,25 @@ def storage_account(test_vars):
 
 
 @pytest.fixture()
-def scp_con(ssh_con):
+def scp_con(ssh_con_fabric):
     """Create an SCP client based on an SSH connection to the controller."""
     log = logging.getLogger("scp_con")
-    client = SCPClient(ssh_con.get_transport())
-    # client = SCPClient(ssh_con.transport)  # FABRIC
+    # client = SCPClient(ssh_con.get_transport())  # PARAMIKO
+    client = SCPClient(ssh_con_fabric.transport)
     yield client
     log.debug("Closing SCP client.")
     client.close()
 
 
 @pytest.fixture()
-def ssh_con(test_vars):
+def ssh_con(ssh_con_fabric):
+    return ssh_con_fabric.client
+
+
+@pytest.fixture()
+def ssh_con_fabric(test_vars):
     """Create an SSH connection to the controller."""
-    log = logging.getLogger("ssh_con")
+    log = logging.getLogger("ssh_con_fabric")
 
     # SSH connection/client to the public IP.
     pub_client = Connection(test_vars["public_ip"],
@@ -162,14 +167,12 @@ def ssh_con(test_vars):
                                     "key_filename": test_vars["ssh_priv_key"],
                                 })
             client.open()
-            yield client.client
-            # yield client  # FABRIC
+            yield client
         log.debug("{} closed".format(msg_con))
     else:
         log.debug("Opening {}".format(msg_con))
         pub_client.open()
-        yield pub_client.client
-        # yield pub_client  # FABRIC
+        yield pub_client
         log.debug("Closing {}".format(msg_con))
 
     pub_client.close()

--- a/test/lib/helpers.py
+++ b/test/lib/helpers.py
@@ -31,6 +31,7 @@ def get_unused_local_port():
     sock.bind(("", 0))
     port = sock.getsockname()[1]
     sock.close()
+    sleep(2)  # for the port to fully free up
     return port
 
 

--- a/test/lib/helpers.py
+++ b/test/lib/helpers.py
@@ -4,6 +4,7 @@
 # standard imports
 import ast
 import logging
+import socket
 from time import sleep, time
 
 # from requirements.txt
@@ -20,6 +21,14 @@ def create_ssh_client(username, hostname, port=22, password=None, key_filename=N
         password=password, key_filename=key_filename
     )
     return ssh_client
+
+
+def get_unused_local_port():
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.bind(("", 0))
+    port = sock.getsockname()[1]
+    sock.close()
+    return port
 
 
 def get_vm_ips(nm_client, resource_group, vm_name):
@@ -90,6 +99,42 @@ def run_ssh_command(ssh_client, command, ignore_nonzero_rc=False, timeout=None):
         "stderr": cmd_err,
         "rc": cmd_rc
     }
+
+
+# def run_ssh_command_fabric(ssh_client, command, ignore_nonzero_rc=False, timeout=None):
+#     """
+#     Run a command on the server connected via ssh_client.
+
+#     If ignore_nonzero_rc is False, assert when a command fails (i.e., non-zero
+#     exit/return code).
+#     """
+#     log = logging.getLogger("run_ssh_command")
+
+#     log.debug("command to run: {}".format(command))
+#     cmd_result = ssh_client.run(command, timeout=timeout)
+
+#     cmd_rc = cmd_out.channel.recv_exit_status()
+#     log.debug("command exit code: {}".format(cmd_rc))
+
+#     cmd_out = "".join(cmd_out.readlines())
+#     log.debug("command output (stdout): {}".format(cmd_out))
+
+#     cmd_err = "".join(cmd_err.readlines())
+#     log.debug("command output (stderr): {}".format(cmd_err))
+
+#     if cmd_rc and not ignore_nonzero_rc:
+#         log.error(
+#             '"{}" failed with exit code {}\n\tSTDOUT: {}\n\tSTDERR: {}'.format(
+#                 command, cmd_rc, cmd_out, cmd_err)
+#         )
+#         assert(0 == cmd_rc)
+
+#     return {
+#         "command": command,
+#         "stdout": cmd_out,
+#         "stderr": cmd_err,
+#         "rc": cmd_rc
+#     }
 
 
 def run_ssh_commands(ssh_client, commands, **kwargs):

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -1,7 +1,7 @@
 azure.mgmt.network
 azure.mgmt.resource
 azure.mgmt.storage
-paramiko
+fabric
 pytest
 scp
 sshtunnel

--- a/test/test_vfxt_cluster_status.py
+++ b/test/test_vfxt_cluster_status.py
@@ -15,7 +15,8 @@ from fabric import Connection
 from scp import SCPClient
 
 # local libraries
-from lib.helpers import (run_averecmd, run_ssh_commands, upload_gsi)
+from lib.helpers import (get_unused_local_port, run_averecmd, run_ssh_commands,
+                         upload_gsi)
 
 
 class TestVfxtClusterStatus:
@@ -122,16 +123,17 @@ class TestVfxtSupport:
                                    method="node.get",
                                    args=node)[node]["primaryClusterIP"]["IP"]
             log.debug("Tunneling to node {} using IP {}".format(node, node_ip))
+            tunnel_local_port = get_unused_local_port()
             with Connection(test_vars["public_ip"],
                             user=test_vars["controller_user"],
                             connect_kwargs={
                                 "key_filename": test_vars["ssh_priv_key"],
-                            }).forward_local(local_port=2222,
+                            }).forward_local(local_port=tunnel_local_port,
                                              remote_port=22,
                                              remote_host=node_ip):
                 node_c = Connection("127.0.0.1",
                                     user="admin",
-                                    port=2222,
+                                    port=tunnel_local_port,
                                     connect_kwargs={
                                         "password": os.environ["AVERE_ADMIN_PW"]
                                     })


### PR DESCRIPTION
Bare Paramiko calls can sometimes result in hung thread locks. Using Fabric calls instead (which use Paramiko under the hood) seems to reduce (or perhaps alleviate/eliminate) the frequency of those locks.

This is a first pass at transitioning Paramiko calls to Fabric. More updates coming.