### PR TITLE
Retry tunnel connection; other misc fixes

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -84,10 +84,13 @@ jobs:
       declare -a common_errors=(
         "Operation results in exceeding quota limits"
         "A hash conflict was encountered for the role Assignment ID"
+        "Corefiler configured with empty bucket but bucket \S+ has existing data"
       )
 
+      echo
+      echo
       for ce in "${common_errors[@]}"; do
-          grep_res=$(grep "$ce" $deploy_results_file)
+          grep_res=$(grep -E "$ce" $deploy_results_file)
           if [[ -n $grep_res ]]; then
               echo "MESSAGE FOUND: $ce"
               msg_found=1
@@ -96,6 +99,9 @@ jobs:
 
       if [[ -z $msg_found ]]; then
         echo "No common error messages found in $deploy_results_file"
+        echo
+        echo
+        echo "Dumping $deploy_results_file:"
         cat $deploy_results_file
         exit 1
       fi

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -38,6 +38,7 @@ jobs:
     condition: succeeded()
 
   - script: |
+      echo "\$VFXT_DEPLOY_LOCATION  = $VFXT_DEPLOY_LOCATION"
       echo "\$VFXT_DEPLOY_NEW_VNET  = $VFXT_DEPLOY_NEW_VNET"
       echo "\$VFXT_DEPLOY_WITH_BLOB = $VFXT_DEPLOY_WITH_BLOB"
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -37,12 +37,6 @@ def pytest_addoption(parser):
         help="Azure region short name to use for deployments (default: westus2)",
     )
     parser.addoption(
-        "--prefer_cli_args", action="store_true",
-        default=False,
-        help="When specified, prioritize custom command-line arguments over "
-        + "the values in the file pointed to by \"test_vars_file\".",
-    )
-    parser.addoption(
         "--ssh_priv_key", action="store",
         default=os.path.expanduser(r"~/.ssh/id_rsa"),
         help="SSH private key to use in deployments and tests (default: ~/.ssh/id_rsa)",
@@ -57,9 +51,8 @@ def pytest_addoption(parser):
         default=envar_check("VFXT_TEST_VARS_FILE"),
         help="Test variables file used for passing values between runs. This "
         + "file is in JSON format. It is loaded during test setup and written "
-        + "out during test teardown. The contents of this file override other "
-        + "custom command-line options unless the \"prefer_cli_args\" option "
-        + "is specified. (default: $VFXT_TEST_VARS_FILE if set, else None)"
+        + "out during test teardown. Command-line options override variables "
+        + "in this file. (default: $VFXT_TEST_VARS_FILE if set, else None)"
     )
 
 
@@ -219,9 +212,8 @@ def test_vars(request):
                 json.dumps(vars, **cja)))
 
     # Override test_vars_file values with command-line arguments.
-    if request.config.getoption("--prefer_cli_args"):
-        vars = {**vars, **cl_opts}
-        log.debug("Overwrote vars with command-line args: {}".format(
+    vars = {**vars, **cl_opts}
+    log.debug("Overwrote vars with command-line args: {}".format(
               json.dumps(vars, **cja)))
 
     atd_obj = ArmTemplateDeploy(_fields={**vars})

--- a/test/test_vfxt_cluster_status.py
+++ b/test/test_vfxt_cluster_status.py
@@ -136,70 +136,76 @@ class TestVfxtSupport:
                                    args=node)[node]["primaryClusterIP"]["IP"]
 
             log.debug("Tunneling to node {} using IP {}".format(node, node_ip))
-            tunnel_local_port = get_unused_local_port()
-            with Connection(test_vars["public_ip"],
-                            user=test_vars["controller_user"],
-                            connect_kwargs={
-                                "key_filename": test_vars["ssh_priv_key"],
-                            }).forward_local(local_port=tunnel_local_port,
-                                             remote_port=22,
-                                             remote_host=node_ip):
-                node_c = Connection("127.0.0.1",
-                                    user="admin",
-                                    port=tunnel_local_port,
-                                    connect_kwargs={
-                                        "password": os.environ["AVERE_ADMIN_PW"]
-                                    })
 
-                # get_unused_local_port actually uses the port to know it's
-                # available before making it available again and returning the
-                # port number. Rarely, there is a race where the open() call
-                # below fails because the port is not yet fully available
-                # again. Retry the open() call a few times to help.
-                for i in range(1, 6):
+            # get_unused_local_port actually uses the port to know it's
+            # available before making it available again and returning the
+            # port number. Rarely, there is a race where the open() call
+            # below fails because the port is not yet fully available
+            # again. In those cases, try getting a new port.
+            for port_attempt in range(1, 11):
+                tunnel_local_port = get_unused_local_port()
+                with Connection(test_vars["public_ip"],
+                                user=test_vars["controller_user"],
+                                connect_kwargs={
+                                    "key_filename": test_vars["ssh_priv_key"],
+                                }).forward_local(local_port=tunnel_local_port,
+                                                 remote_port=22,
+                                                 remote_host=node_ip):
+                    node_c = Connection("127.0.0.1",
+                                        user="admin",
+                                        port=tunnel_local_port,
+                                        connect_kwargs={
+                                            "password": os.environ["AVERE_ADMIN_PW"]
+                                        })
                     try:
                         node_c.open()
-                        break
+
+                        # If port_attempt > 1, last_error had the exception
+                        # from the last iteration. Clear it.
+                        last_error = None
                     except NoValidConnectionsError as ex:
+                        last_error = ex
                         exp_err = "Unable to connect to port {} on 127.0.0.1".format(tunnel_local_port)
                         if exp_err not in str(ex):
                             raise
                         else:
-                            log.warn(exp_err + " (attempt #{})".str(i))
-                            sleep(1)
+                            log.warn("{0} (attempt #{1}, retrying)".format(
+                                     exp_err, str(port_attempt)))
+                            continue  # iterate
 
-                scp_client = SCPClient(node_c.transport)
-                try:
-                    # Calls below catch exceptions and report them to the
-                    # error log, but then continue. This is because a
-                    # failure to collect artifacts on one node should not
-                    # prevent collection from other nodes. After collection
-                    # has completed, the last exception will be raised.
+                    scp_client = SCPClient(node_c.transport)
+                    try:
+                        # Calls below catch exceptions and report them to the
+                        # error log, but then continue. This is because a
+                        # failure to collect artifacts on one node should not
+                        # prevent collection from other nodes. After collection
+                        # has completed, the last exception will be raised.
 
-                    # list of files and directories to download
-                    to_collect = [
-                        "/var/log/messages",
-                        "/var/log/xmlrpc.log",
+                        # list of files and directories to download
+                        to_collect = [
+                            "/var/log/messages",
+                            "/var/log/xmlrpc.log",
 
-                        # assumes rolling trace was enabled during deploy
-                        "/support/trace/rolling",
+                            # assumes rolling trace was enabled during deploy
+                            "/support/trace/rolling",
 
-                        # TODO: 2019-0219: turned off for now
-                        # "/support/gsi",
-                        # "/support/cores",
-                    ]
-                    for tc in to_collect:
-                        log.debug("SCP'ing {} from node {} to {}".format(
-                                  tc, node, node_dir_log))
-                        try:
-                            scp_client.get(tc, node_dir_log, recursive=True)
-                        except Exception as ex:
-                            log.error("({}) Exception caught: {}".format(
-                                      node, ex))
-                            last_error = ex
-                finally:
-                    scp_client.close()
-            log.debug("Connections to node {} closed".format(node))
+                            # TODO: 2019-0219: turned off for now
+                            # "/support/gsi",
+                            # "/support/cores",
+                        ]
+                        for tc in to_collect:
+                            log.debug("SCP'ing {} from node {} to {}".format(
+                                    tc, node, node_dir_log))
+                            try:
+                                scp_client.get(tc, node_dir_log, recursive=True)
+                            except Exception as ex:
+                                log.error("({}) Exception caught: {}".format(
+                                        node, ex))
+                                last_error = ex
+                    finally:
+                        scp_client.close()
+                log.debug("Connections to node {} closed".format(node))
+                break  # no need to iterate again
 
         if last_error:
             log.error("See previous error(s) above. Raising last exception.")

--- a/test/test_vfxt_template_deploy.py
+++ b/test/test_vfxt_template_deploy.py
@@ -83,7 +83,7 @@ class TestVfxtTemplateDeploy:
           - create a new VNET
           - do NOT use an Avere-backed storage account
         """
-        log = logging.getLogger("test_deploy_template")
+        log = logging.getLogger("test_no_storage_account_deploy")
         atd = test_vars["atd_obj"]
         with open("{}/src/vfxt/azuredeploy-auto.json".format(
                   test_vars["build_root"])) as tfile:
@@ -139,7 +139,7 @@ class TestVfxtTemplateDeploy:
           - do NOT create a new VNET
           - use an Avere-backed storage account
         """
-        log = logging.getLogger("test_deploy_template_byovnet")
+        log = logging.getLogger("test_byovnet_deploy")
         atd = test_vars["atd_obj"]
         with open("{}/src/vfxt/azuredeploy-auto.json".format(
                   test_vars["build_root"])) as tfile:
@@ -173,7 +173,7 @@ class TestVfxtTemplateDeploy:
         log.debug("Generated deploy parameters: \n{}".format(
                   json.dumps(atd.deploy_params, indent=4)))
 
-        atd.deploy_name = "test_deploy_template_byovnet"
+        atd.deploy_name = "test_byovnet_deploy"
         try:
             deploy_outputs = wait_for_op(atd.deploy()).properties.outputs
             test_vars["cluster_mgmt_ip"] = deploy_outputs["mgmt_ip"]["value"]


### PR DESCRIPTION
When looking for a free network port, we actually connect to a system-chosen port first then disconnect from that port and return the port number. There seems to be an occasional race where the port isn't yet fully disconnected/available. This change attempts to address this by retrying the port connection five times (with a one-second sleep between tries).

Some other miscellaneous fixes are included:
- Added a new "common deploy error message" to the Pipelines YAML.
- Added timeouts to the commands in the mnt_nodes fixture (particularly for the mount command, which sometimes hangs).
- Renamed test_ping_nodes to test_ping_vservers.
- Fixed up some logger names in test_vfxt_template_deploy.py.