### PR TITLE
Added resiliency for averecmd to collect logs, etc

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -214,6 +214,12 @@ jobs:
         --doctest-modules --junitxml=junit/test-results03.xml
       pyt_res=$?
 
+      # Copy VFXT_TEST_VARS_FILE to the artifacts directory.
+      if [[ -f $VFXT_TEST_VARS_FILE ]]; then
+        cat $VFXT_TEST_VARS_FILE
+        cp $VFXT_TEST_VARS_FILE $P_ARTIFACTS_DIR/.
+      fi
+
       # Get controller logs in case the pytest call failed.
       vfxt_log_loc=$(find ${BUILD_SOURCESDIRECTORY} -name vfxt.log)
       if [ -z "$vfxt_log_loc" ]; then

--- a/test/test_vfxt_cluster_status.py
+++ b/test/test_vfxt_cluster_status.py
@@ -114,7 +114,7 @@ class TestVfxtSupport:
 
         assert(not cores_found)
 
-    def test_artifacts_collect(self, averecmd_params, scp_con, test_vars):  # noqa: F811, E501
+    def test_artifacts_collect(self, averecmd_params, node_names, scp_con, test_vars):  # noqa: F811, E501
         """
         Collect test artifacts (node logs, rolling trace) from each node.
         Artifacts are stored to local directories.
@@ -131,10 +131,8 @@ class TestVfxtSupport:
         scp_con.put(test_vars["ssh_priv_key"], "~/.ssh/.")
         scp_con.put(test_vars["ssh_pub_key"], "~/.ssh/.")
 
-        nodes = run_averecmd(**averecmd_params, method="node.list")
-        log.debug("Nodes found: {}".format(nodes))
         last_error = None
-        for node in nodes:
+        for node in node_names:
             node_dir = artifacts_dir + "/" + node
             node_dir_log = node_dir + "/log"
             node_dir_trace = node_dir + "/trace"

--- a/test/test_vfxt_cluster_status.py
+++ b/test/test_vfxt_cluster_status.py
@@ -48,7 +48,8 @@ class TestVfxtClusterStatus:
                 if node_state == "up":
                     # Save the node IPs while we're here.
                     node_ips[node] = [x["IP"] for x in result[node]["clusterIPs"]]
-                    node_ips[node].append(result[node]["clientFacingIPs"]["vserver"][0]["IP"])
+                    if result[node]["clientFacingIPs"]["vserver"]:
+                        node_ips[node].append(result[node]["clientFacingIPs"]["vserver"][0]["IP"])
                     break
                 sleep(10)
             assert node_state == "up"


### PR DESCRIPTION
This is a larger iteration of attempting to diagnose/fix the hung mount command issue.

One of the issues we see when the mount command hangs is that subsequent XML RPCs to the cluster fail. Assuming a node went down (and thus the hung mount), the XML RPCs could be failing because they are attempting to hit a cluster management IP that may be migrating. As a result, we can't collect node logs, check for cores, etc.

This change attempts to alleviate this situation by trying averecmd calls against various cluster IPs. It doesn't fix the hung mount issue, but should (hopefully) help us collect more information in tracking that down.

Also, a new test case appears (test_ping_node_ips)! And some other test case re-ordering and cleanup.