### PR TITLE
add writers to codeowners for docs

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -11,3 +11,7 @@
 # owners will be requested for a review.
 *.py    @omzevall @rebecca-makar
 
+# Documentation people should review items in these paths 
+/docs/*  @ekpgh @anhowe
+/docs/legacy/* @ekpgh @ronhogue 
+


### PR DESCRIPTION
I'm not sure if this syntax is right (any way to test it?) - but my intent is to add myself and other doc-focused people as automatic reviewers for files within the public-facing documentation and legacy docs subsections. 
- Should the overall code owners also be notified/asked for reviews? 
- Should different people be involved than I used?