### PR TITLE
adding a dockerfile here that will build the provider and place it in…

### DIFF
--- a/src/terraform/providers/docker/Dockerfile
+++ b/src/terraform/providers/docker/Dockerfile
@@ -1,0 +1,18 @@
+FROM hashicorp/terraform:full
+
+ENV GOPATH /go
+
+RUN mkdir -p $GOPATH
+
+RUN go get -v github.com/Azure/Avere/src/terraform/providers/terraform-provider-avere; exit 0
+
+WORKDIR $GOPATH/src/github.com/Azure/Avere/src/terraform/providers/terraform-provider-avere
+RUN go mod download
+RUN go mod tidy
+RUN go build
+RUN mkdir -p ~/.terraform.d/plugins
+RUN cp terraform-provider-avere ~/.terraform.d/plugins
+
+WORKDIR ~
+
+ENTRYPOINT ["terraform"]


### PR DESCRIPTION
…to .terraform.d/plugins/ so that it can immediately be used in CI / CD pipelines. this image is based off of hashicorp/terraform:full

example usage:

git clone https://github.com/Azure/Avere.git
cd Azure/src/terraform/providers/docker
docker build . -t <dockerhub_username>/terraform-azure:latest
docker push <dockerhub_username>/terraform-azure:latest

and use <dockerhub_username>/terraform-azure:latest as the image in your CI pipeline, terraform init should find the plugin no issue.