### PR TITLE
Opencue updates

### DIFF
--- a/src/clientapps/opencue/README.md
+++ b/src/clientapps/opencue/README.md
@@ -1,3 +1,3 @@
 # OpenCue on Azure
 
-This template implements OpenCue.
+This template implements OpenCue RQD client onto the machine executing the script.

--- a/src/clientapps/opencue/bootstrap.sh
+++ b/src/clientapps/opencue/bootstrap.sh
@@ -8,12 +8,12 @@
 # Save this script to any Avere vFXT volume, for example:
 #     /bootstrap/bootstrap.sh
 #
-# The following environment variables must be set:
-#     NFS_IP_CSV="10.0.0.22,10.0.0.23,10.0.0.24"
-#     NFS_PATH=/msazure
-#     BASE_DIR=/nfs
-#     CUEBOT_HOSTNAME="10.0.0.30"
-#     CUEBOT_FS_ROOT=$BASE_DIR/opencue-demo
+# The following environment variables must be set, example values below that may not match your environment:
+#     NFS_IP_CSV="10.0.0.22,10.0.0.23,10.0.0.24" # the ip addresses for your NFS (vFXT, ot HPC Cache) servers in CSV format
+#     NFS_PATH=/msazure # the path on the NFS server that you want to mount
+#     BASE_DIR=/nfs # base directory where your NFS server will be mounted
+#     CUEBOT_HOSTNAME="10.0.0.30" # Cuebot IP address (or hostname)
+#     CUEBOT_FS_ROOT=$BASE_DIR/opencue-demo # Cuebot filesystem root, used to store Cuebot logs
 #
 set -x
 NODE_MOUNT_PREFIX="/node"
@@ -81,21 +81,22 @@ function main() {
         mount_all
     fi
 
-    # Install PBRT on nodes
-    # https://github.com/mmp/pbrt-v3/
-    # cd ~
-    # apt install -yq cmake build-essential gcc-4.8 g++-4.8 make bison flex libpthread-stubs0-dev
-    # update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.8 40 --slave /usr/bin/g++ g++ /usr/bin/g++-4.8
-    # git clone --recursive https://github.com/mmp/pbrt-v3/
-    # mkdir pbrt
-    # cd pbrt
-    # cmake -DCMAKE_BUILD_TYPE=Release ../pbrt-v3/
-    # make
+    # Build and install PBRT on render nodes
+    # Reference: https://github.com/mmp/pbrt-v3/
+    cd /
+    apt install -yq cmake build-essential gcc-4.8 g++-4.8 make bison flex libpthread-stubs0-dev
+    update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.8 40 --slave /usr/bin/g++ g++ /usr/bin/g++-4.8
+    git clone --recursive https://github.com/mmp/pbrt-v3/
+    mkdir pbrt
+    cd pbrt
+    cmake -DCMAKE_BUILD_TYPE=Release ../pbrt-v3/
+    make
 
     # Use pre-built pbrt tools
-    echo "copy PBRT from cache to /opencue-tools/tools/pbrt-release/pbrt"
-    mkdir /opencue-tools
-    cp -r "${BASE_DIR}/opencue-demo/tools" /opencue-tools
+    # If you have pre-built PBRT (or another render engine and it is stored on your NFS server) you can copy it to your render nodes for use
+    # echo "copy PBRT from cache to /opencue-tools/tools/pbrt-release/pbrt"
+    # mkdir /opencue-tools
+    # cp -r "${BASE_DIR}/opencue-demo/tools" /opencue-tools
 
 
     # Set up the RQD environment on each node
@@ -114,7 +115,7 @@ function main() {
     # python3 setup.py install
     
     # apt based install
-    apt-get -y install python3 python3-dev python3-pip gcc
+    apt install -yq python3 python3-dev python3-pip gcc
     cd ~
     echo "CUEBOT_HOSTNAME=$CUEBOT_HOSTNAME"
     echo "CUE_FS_ROOT=$CUE_FS_ROOT"

--- a/src/terraform/examples/vfxt/opencue/pre-existing-azure-blob/moanaislandscenescripts/renderAll.sh
+++ b/src/terraform/examples/vfxt/opencue/pre-existing-azure-blob/moanaislandscenescripts/renderAll.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 
-# /datadrive/pbrt/release/pbrt -outfile /home/AzureUser/island.png island.pbrt
-/datadrive/pbrt/release/pbrt -outfile /home/AzureUser/islandX.png islandX.pbrt > islandX.log
-/datadrive/pbrt/release/pbrt -outfile /home/AzureUser/island_beachCam.png island_beachCam.pbrt > island_beachCam.log
-/datadrive/pbrt/release/pbrt -outfile /home/AzureUser/island_dunesACam.png island_dunesACam.pbrt > island_dunesACam.log
-/datadrive/pbrt/release/pbrt -outfile /home/AzureUser/island_frame90.png island_frame90.pbrt > island_frame90.log
-/datadrive/pbrt/release/pbrt -outfile /home/AzureUser/island_grassCam.png island_grassCam.pbrt > island_grassCam.log
-/datadrive/pbrt/release/pbrt -outfile /home/AzureUser/island_hibiscusCam.png island_hibiscusCam.pbrt > island_hibiscusCam.log
-/datadrive/pbrt/release/pbrt -outfile /home/AzureUser/island_palmsCam.png island_palmsCam.pbrt > island_palmsCam.log
-/datadrive/pbrt/release/pbrt -outfile /home/AzureUser/island_rootsCam.png island_rootsCam.pbrt > island_rootsCam.log
-/datadrive/pbrt/release/pbrt -outfile /home/AzureUser/island_shotCam.png island_shotCam.pbrt > island_shotCam.log
-/datadrive/pbrt/release/pbrt -outfile /home/AzureUser/island_4096.png island_4096.pbrt > island_4096.log
+/pbrt/release/pbrt -outfile /home/azureuser/island.png island.pbrt > island.log
+/pbrt/release/pbrt -outfile /home/azureuser/islandX.png islandX.pbrt > islandX.log
+/pbrt/release/pbrt -outfile /home/azureuser/island_beachCam.png island_beachCam.pbrt > island_beachCam.log
+/pbrt/release/pbrt -outfile /home/azureuser/island_dunesACam.png island_dunesACam.pbrt > island_dunesACam.log
+/pbrt/release/pbrt -outfile /home/azureuser/island_frame90.png island_frame90.pbrt > island_frame90.log
+/pbrt/release/pbrt -outfile /home/azureuser/island_grassCam.png island_grassCam.pbrt > island_grassCam.log
+/pbrt/release/pbrt -outfile /home/azureuser/island_hibiscusCam.png island_hibiscusCam.pbrt > island_hibiscusCam.log
+/pbrt/release/pbrt -outfile /home/azureuser/island_palmsCam.png island_palmsCam.pbrt > island_palmsCam.log
+/pbrt/release/pbrt -outfile /home/azureuser/island_rootsCam.png island_rootsCam.pbrt > island_rootsCam.log
+/pbrt/release/pbrt -outfile /home/azureuser/island_shotCam.png island_shotCam.pbrt > island_shotCam.log
+/pbrt/release/pbrt -outfile /home/azureuser/island_4096.png island_4096.pbrt > island_4096.log


### PR DESCRIPTION
Generalise opencue bootstrap.sh file for the RQD render nodes - build PBRT by default rather than copy

Add notes on what each expected environment variable is used for

Update sample render script to use the location of PBRT in the bootstrap.sh script and the default user in the terraform script as the output directory