### PR TITLE
ensure scale-up correctly outputs node names and ip addresses

### DIFF
--- a/src/terraform/providers/terraform-provider-avere/averevfxt.go
+++ b/src/terraform/providers/terraform-provider-avere/averevfxt.go
@@ -1015,7 +1015,7 @@ func (a *AvereVfxt) getListNodesJsonCommand() string {
 }
 
 func (a *AvereVfxt) getRemoveNodeCommand(node string) string {
-	return WrapCommandForLogging(fmt.Sprintf("%s --json node.remove %s", a.getBaseAvereCmd(), node), AverecmdLogFile)
+	return WrapCommandForLogging(fmt.Sprintf("%s --json node.remove %s false", a.getBaseAvereCmd(), node), AverecmdLogFile)
 }
 
 func (a *AvereVfxt) getNodeJsonCommand(node string) string {

--- a/src/terraform/providers/terraform-provider-avere/go.sum
+++ b/src/terraform/providers/terraform-provider-avere/go.sum
@@ -174,6 +174,7 @@ github.com/hashicorp/terraform-plugin-sdk v1.9.0 h1:WBHHIX/RgF6/lbfMCzx0qKl96BbQ
 github.com/hashicorp/terraform-plugin-sdk v1.11.0 h1:qAI27eiSdIm0D+GCdlyGwtcWAYkjdVWC7OdS/3XcJq4=
 github.com/hashicorp/terraform-plugin-sdk v1.13.0 h1:8v2/ZNiI12OHxEn8pzJ3noCHyRc0biKbKj+iFv5ZWKw=
 github.com/hashicorp/terraform-plugin-sdk v1.13.1 h1:kWq+V+4BMFKtzIuO8wb/k4SRGB/VVF8g468VSFmAnKM=
+github.com/hashicorp/terraform-plugin-sdk v1.15.0 h1:bmYnTT7MqNXlUHDc7pT8E6uKT2g/upjlRLypJFK1OQU=
 github.com/hashicorp/terraform-svchost v0.0.0-20191011084731-65d371908596 h1:hjyO2JsNZUKT1ym+FAdlBEkGPevazYsmVgIMw7dVELg=
 github.com/hashicorp/terraform-svchost v0.0.0-20191011084731-65d371908596/go.mod h1:kNDNcF7sN4DocDLBkQYz73HGKwN1ANB1blq4lIYLYvg=
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=


### PR DESCRIPTION
fixes #804 .  The set type does not correctly set the state for the computed values, so changing those to list types.