### PR TITLE
add static node ip addresses

### DIFF
--- a/src/terraform/providers/terraform-provider-avere/README.md
+++ b/src/terraform/providers/terraform-provider-avere/README.md
@@ -154,6 +154,7 @@ In addition to all arguments above, the following attributes are exported:
 * <a name="vfxt_management_ip"></a>[vfxt_management_ip](#vfxt_management_ip) - this is the Avere vFXT management ip address.
 * <a name="vserver_ip_addresses"></a>[vserver_ip_addresses](#vserver_ip_addresses) - these are the list of vserver ip addresses.  Clients will mount to these addresses.
 * <a name="node_names"></a>[node_names](#node_names) - these are the node names of the cluster.
+* <a name="primary_cluster_ips"></a>[primary_cluster_ips](#primary_cluster_ips) - these are the static primary ip addresses of the cluster that do not move.
 
 # Build the Terraform Provider binary
 

--- a/src/terraform/providers/terraform-provider-avere/averevfxt.go
+++ b/src/terraform/providers/terraform-provider-avere/averevfxt.go
@@ -185,6 +185,26 @@ func (a *AvereVfxt) GetNodes() ([]string, error) {
 	return results, nil
 }
 
+func (a *AvereVfxt) GetNodePrimaryIPs() ([]string, error) {
+	nodeMap, err := a.GetExistingNodes()
+	if err != nil {
+		return nil, err
+	}
+
+	var results []string
+	for _, v := range nodeMap {
+		if val, ok := v.PrimaryClusterIP[PrimaryClusterIPKey]; ok {
+			results = append(results, val)
+		} else {
+			// this is not essential data, so just print an error
+			log.Printf("[ERROR] primary IP missing for node %s", v.Name)
+			//return nil, fmt.Errorf("primary IP missing for node %s", v.Name)
+		}
+	}
+
+	return results, nil
+}
+
 func (a *AvereVfxt) GetExistingNodes() (map[string]*Node, error) {
 	nodes, err := a.GetNodes()
 	if err != nil {

--- a/src/terraform/providers/terraform-provider-avere/averevfxt.go
+++ b/src/terraform/providers/terraform-provider-avere/averevfxt.go
@@ -1015,7 +1015,7 @@ func (a *AvereVfxt) getListNodesJsonCommand() string {
 }
 
 func (a *AvereVfxt) getRemoveNodeCommand(node string) string {
-	return WrapCommandForLogging(fmt.Sprintf("%s --json node.remove %s", a.getBaseAvereCmd(), node), AverecmdLogFile)
+	return WrapCommandForLogging(fmt.Sprintf("%s --json node.remove %s false", a.getBaseAvereCmd(), node), AverecmdLogFile)
 }
 
 func (a *AvereVfxt) getNodeJsonCommand(node string) string {

--- a/src/terraform/providers/terraform-provider-avere/constants.go
+++ b/src/terraform/providers/terraform-provider-avere/constants.go
@@ -78,6 +78,8 @@ const (
 	// the share permssions
 	PermissionsPreserve = "preserve" // this is the default for NFS shares
 	PermissionsModebits = "modebits" // this is the default for the Azure Storage Share
+
+	PrimaryClusterIPKey = "IP"
 )
 
 // terraform schema constants - avoids bugs on schema name changes
@@ -132,4 +134,5 @@ const (
 	vserver_ip_addresses         = "vserver_ip_addresses"
 	node_names                   = "node_names"
 	junction_namespace_path      = "junction_namespace_path"
+	primary_cluster_ips          = "primary_cluster_ips"
 )

--- a/src/terraform/providers/terraform-provider-avere/go.sum
+++ b/src/terraform/providers/terraform-provider-avere/go.sum
@@ -174,6 +174,7 @@ github.com/hashicorp/terraform-plugin-sdk v1.9.0 h1:WBHHIX/RgF6/lbfMCzx0qKl96BbQ
 github.com/hashicorp/terraform-plugin-sdk v1.11.0 h1:qAI27eiSdIm0D+GCdlyGwtcWAYkjdVWC7OdS/3XcJq4=
 github.com/hashicorp/terraform-plugin-sdk v1.13.0 h1:8v2/ZNiI12OHxEn8pzJ3noCHyRc0biKbKj+iFv5ZWKw=
 github.com/hashicorp/terraform-plugin-sdk v1.13.1 h1:kWq+V+4BMFKtzIuO8wb/k4SRGB/VVF8g468VSFmAnKM=
+github.com/hashicorp/terraform-plugin-sdk v1.15.0 h1:bmYnTT7MqNXlUHDc7pT8E6uKT2g/upjlRLypJFK1OQU=
 github.com/hashicorp/terraform-svchost v0.0.0-20191011084731-65d371908596 h1:hjyO2JsNZUKT1ym+FAdlBEkGPevazYsmVgIMw7dVELg=
 github.com/hashicorp/terraform-svchost v0.0.0-20191011084731-65d371908596/go.mod h1:kNDNcF7sN4DocDLBkQYz73HGKwN1ANB1blq4lIYLYvg=
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=

--- a/src/terraform/providers/terraform-provider-avere/resource_vfxt.go
+++ b/src/terraform/providers/terraform-provider-avere/resource_vfxt.go
@@ -355,6 +355,13 @@ func resourceVfxt() *schema.Resource {
 					Type: schema.TypeString,
 				},
 			},
+			primary_cluster_ips: {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
 		},
 	}
 }
@@ -494,6 +501,16 @@ func resourceVfxtRead(d *schema.ResourceData, m interface{}) error {
 	if len(*(avereVfxt.NodeNames)) >= MinNodesCount {
 		d.Set(vfxt_node_count, len(*(avereVfxt.NodeNames)))
 	}
+
+	primaryIPs, err := avereVfxt.GetNodePrimaryIPs()
+	if err != nil {
+		return fmt.Errorf("error encountered getting nodes primary ips '%v'", err)
+	}
+	d.Set(primary_cluster_ips, flattenStringSlice(&primaryIPs))
+	if len(*(avereVfxt.NodeNames)) >= MinNodesCount {
+		d.Set(vfxt_node_count, len(*(avereVfxt.NodeNames)))
+	}
+
 	return nil
 }
 

--- a/src/terraform/providers/terraform-provider-avere/types.go
+++ b/src/terraform/providers/terraform-provider-avere/types.go
@@ -65,8 +65,9 @@ type NFSExport struct {
 }
 
 type Node struct {
-	Name  string `json:"name"`
-	State string `json:"state"`
+	Name             string            `json:"name"`
+	State            string            `json:"state"`
+	PrimaryClusterIP map[string]string `json:"primaryClusterIP"`
 }
 
 type VServerClientIPHome struct {


### PR DESCRIPTION
fixes #794 

This is useful if you need to connect to multiple nodes, and you do not want the IPs to move while an AOS service is restarting.