### PR TITLE
Fix read only cache policy

### DIFF
--- a/src/terraform/providers/terraform-provider-avere/README.md
+++ b/src/terraform/providers/terraform-provider-avere/README.md
@@ -138,7 +138,7 @@ A <a name="core_filer"></a>`core_filer` block supports the following:
     | "Full Caching" | Use this cache policy with cloud core filers or to optimize for op reduction to the core filer. |
     | "Isolated Cloud Workstation" | useful for vdi workstations reading and writing to separate locations as described in [Cloud Workstations](../../examples/vfxt/cloudworkstation) |
     | "Collaborating Cloud Workstation" | useful for vdi workstations reading and writing to the same content as described in [Cloud Workstations](../../examples/vfxt/cloudworkstation) |
-    | "Read Only High Write Back Delay" | Use this for read heavy content, where changes in the data are infrequent. |
+    | "Read Only High Verification Time" | Use this for read heavy data, where changes in the data are infrequent. |
 * <a name="custom_settings_2"></a>[custom_settings](#custom_settings_2) - (Optional) - these are custom settings provided by Avere support to match advanced use case scenarios.  They are a list of strings of the form "SETTINGNAME CHECKCODE VALUE".  Do not prefix with the mass name as it is automatically detected.
 * [junction](#junction) - (Required) this specifies the junction block as described below.
  

--- a/src/terraform/providers/terraform-provider-avere/averevfxt.go
+++ b/src/terraform/providers/terraform-provider-avere/averevfxt.go
@@ -592,8 +592,8 @@ func (a *AvereVfxt) EnsureCachePolicy(corefiler *CoreFiler) error {
 		return a.EnsureCachePolicyExists(CachePolicyIsolatedCloudWorkstation, CacheModeReadWrite, CachePolicyIsolatedCloudWorkstationCheckAttributes, WriteBackDelayDefault)
 	case CachePolicyCollaboratingCloudWorkstation:
 		return a.EnsureCachePolicyExists(CachePolicyCollaboratingCloudWorkstation, CacheModeReadWrite, CachePolicyCollaboratingCloudWorkstationCheckAttributes, WriteBackDelayDefault)
-	case CachePolicyReadOnlyHighWriteBackDelay:
-		return a.EnsureCachePolicyExists(CachePolicyReadOnlyHighWriteBackDelay, CacheModeReadOnly, "", CachePolicyReadOnlyHighWriteBackDelayValue)
+	case CachePolicyReadOnlyHighVerificationTime:
+		return a.EnsureCachePolicyExists(CachePolicyReadOnlyHighVerificationTime, CacheModeReadOnly, CachePolicyReadOnlyHighVerificationTimeCheckAttributes, 0)
 	default:
 		return fmt.Errorf("Error: core filer '%s' specifies unknown cache policy '%s'", corefiler.Name, corefiler.CachePolicy)
 	}

--- a/src/terraform/providers/terraform-provider-avere/constants.go
+++ b/src/terraform/providers/terraform-provider-avere/constants.go
@@ -31,11 +31,11 @@ const (
 	CachePolicyTransitioningClients          = "Transitioning Clients Before or After a Migration"
 	CachePolicyIsolatedCloudWorkstation      = "Isolated Cloud Workstation"
 	CachePolicyCollaboratingCloudWorkstation = "Collaborating Cloud Workstation"
-	CachePolicyReadOnlyHighWriteBackDelay    = "Read Only High Write Back Delay"
+	CachePolicyReadOnlyHighVerificationTime  = "Read Only High Verification Time"
 
 	CachePolicyIsolatedCloudWorkstationCheckAttributes      = "{}"
 	CachePolicyCollaboratingCloudWorkstationCheckAttributes = "{'checkAttrPeriod':30,'checkDirAttrPeriod':30}"
-	CachePolicyReadOnlyHighWriteBackDelayValue              = 10800
+	CachePolicyReadOnlyHighVerificationTimeCheckAttributes  = "{'checkAttrPeriod':10800,'checkDirAttrPeriod':10800}"
 
 	CacheModeReadWrite = "read-write"
 	CacheModeReadOnly  = "read"

--- a/src/terraform/providers/terraform-provider-avere/resource_vfxt.go
+++ b/src/terraform/providers/terraform-provider-avere/resource_vfxt.go
@@ -265,7 +265,7 @@ func resourceVfxt() *schema.Resource {
 								CachePolicyTransitioningClients,
 								CachePolicyIsolatedCloudWorkstation,
 								CachePolicyCollaboratingCloudWorkstation,
-								CachePolicyReadOnlyHighWriteBackDelay,
+								CachePolicyReadOnlyHighVerificationTime,
 							}, false),
 						},
 						custom_settings: {

--- a/src/terraform/providers/terraform-provider-avere/restore_backup.go
+++ b/src/terraform/providers/terraform-provider-avere/restore_backup.go
@@ -97,7 +97,7 @@ func getUsageModel(cachePolicy string) string {
 	case CachePolicyClientsBypass, CachePolicyIsolatedCloudWorkstation, CachePolicyCollaboratingCloudWorkstation, CachePolicyTransitioningClients:
 		return UsageModelWriteAround
 
-	case CachePolicyReadCaching, CachePolicyReadOnlyHighWriteBackDelay:
+	case CachePolicyReadCaching, CachePolicyReadOnlyHighVerificationTime:
 		return UsageModelReadHeavyInfreq
 
 	case CachePolicyReadWriteCaching, CachePolicyFullCaching:


### PR DESCRIPTION
Fix for #762 

There was a misunderstanding in the configuration of the cache policy, it is not a high write back delay, but a high core filer verification time.