### PR TITLE
left-padding of HOST_NUMBER_HEX to increase support from 15->255 vdbench loadgen clients

### DIFF
--- a/src/clientapps/vdbench/bootstrap.vdbench.sh
+++ b/src/clientapps/vdbench/bootstrap.vdbench.sh
@@ -235,7 +235,7 @@ EOM
     COUNTER=0
     while [ $COUNTER -lt $NODE_COUNT ]; do
         HOST_NUMBER=$(($COUNTER + 1))
-        HOST_NUMBER_HEX=$( printf '%x' $HOST_NUMBER )
+        HOST_NUMBER_HEX=$( printf '%02x' $HOST_NUMBER )
         NODE_NAME="${NODE_PREFIX}-${COUNTER}"
         IP=$( host ${NODE_NAME}${DNS_SUFFIX} ${HOST_DNS_SERVER} | grep ${NODE_NAME} | grep -oE '((1?[0-9][0-9]?|2[0-4][0-9]|25[0-5])\.){3}(1?[0-9][0-9]?|2[0-4][0-9]|25[0-5])' )
         echo "NODE NAME ${NODE_NAME}, $IP"
@@ -279,7 +279,7 @@ EOM
     FAILURE_MAX=255
     while (( (COUNTER-FAILURE_COUNTER) < NODE_COUNT && FAILURE_COUNTER < $FAILURE_MAX )); do
         HOST_NUMBER=$[1+($COUNTER-$FAILURE_COUNTER)]
-        HOST_NUMBER_HEX=$( printf '%x' $HOST_NUMBER )
+        HOST_NUMBER_HEX=$( printf '%02x' $HOST_NUMBER )
         VMSS_INDEX=$COUNTER
         VMSS_INDEX_HEX=$( printf '%06x' $VMSS_INDEX )
         NODE_NAME="${NODE_PREFIX}${VMSS_INDEX_HEX}"

--- a/src/clientapps/vdbench/bootstrap.vdbench.sh
+++ b/src/clientapps/vdbench/bootstrap.vdbench.sh
@@ -56,7 +56,7 @@ ensureAzureNetwork()
         # these are VM nodes, count the VMs
         while [ $COUNTER -lt $NODE_COUNT ]; do
             HOST_NUMBER=$(($COUNTER + 1))
-            HOST_NUMBER_HEX=$( printf '%x' $HOST_NUMBER )
+            HOST_NUMBER_HEX=$( printf '%02x' $HOST_NUMBER )
             NODE_NAME="${NODE_PREFIX}-${COUNTER}"
             host ${NODE_NAME}${DNS_SUFFIX} ${HOST_DNS_SERVER}
             if [ $? -ne 0 ]


### PR DESCRIPTION
Fixed an issue that was limiting vdbench to no more than 15 loadgen clients. This update will allow support for up to 255 clients.