### PR TITLE
Update Automation

### DIFF
--- a/test/lib/helpers.py
+++ b/test/lib/helpers.py
@@ -200,7 +200,7 @@ def upload_gsi(averecmd_params):
                           args='cluster gsimin')
     log.debug("GSI upload job ID: {}".format(job_id))
 
-    timeout_secs = 60 * 10
+    timeout_secs = 120 * 10
     time_start = time()
     time_end = time_start + timeout_secs
     gsi_upload_done = False

--- a/test/test_vfxt_cluster_status.py
+++ b/test/test_vfxt_cluster_status.py
@@ -216,7 +216,7 @@ class TestVfxtSupport:
                             "/var/log/xmlrpc.log",
 
                             # assumes rolling trace was enabled during deploy
-                            "/support/trace/rolling",
+                            # "/support/trace/rolling",
 
                             # TODO: 2019-0219: turned off for now
                             # "/support/gsi",


### PR DESCRIPTION
Two quick changes in anticipation of new images:
1. Increase GSI collection timeout
2. Do not download rolling trace by default

Successfully tested with and without the preview version of upcoming images.