### PR TITLE
Resolve AzureRM provider version warning in Terraform examples

### DIFF
--- a/src/terraform/examples/HPC Cache/1-filer/main.tf
+++ b/src/terraform/examples/HPC Cache/1-filer/main.tf
@@ -43,9 +43,17 @@ locals {
     vm_ssh_key_data = null //"ssh-rsa AAAAB3...."
 }
 
+terraform {
+	required_providers {
+		azurerm = {
+			source  = "hashicorp/azurerm"
+			version = "~>2.12.0"
+		}
+	}
+}
+
 provider "azurerm" {
-    version = "~>2.12.0"
-    features {}
+	features {}
 }
 
 // the render network

--- a/src/terraform/examples/HPC Cache/3-filers/main.tf
+++ b/src/terraform/examples/HPC Cache/3-filers/main.tf
@@ -44,9 +44,17 @@ locals {
    
 }
 
+terraform {
+	required_providers {
+		azurerm = {
+			source  = "hashicorp/azurerm"
+			version = "~>2.12.0"
+		}
+	}
+}
+
 provider "azurerm" {
-    version = "~>2.12.0"
-    features {}
+	features {}
 }
 
 // the render network

--- a/src/terraform/examples/HPC Cache/azureblobfiler/main.tf
+++ b/src/terraform/examples/HPC Cache/azureblobfiler/main.tf
@@ -35,7 +35,7 @@ locals {
     // storage details
     storage_resource_group_name = "storage_resource_group"
     // create a globally unique name for the storage account
-    storage_account_name = ""
+    storage_account_name = "gdgdgdgdgdg"
     avere_storage_container_name = "hpccache"
 
     // per the hpc cache documentation: https://docs.microsoft.com/en-us/azure/hpc-cache/hpc-cache-add-storage
@@ -48,9 +48,17 @@ locals {
     hpc_cache_principal_name = "HPC Cache Resource Provider"
 }
 
+terraform {
+	required_providers {
+		azurerm = {
+			source  = "hashicorp/azurerm"
+			version = "~>2.12.0"
+		}
+	}
+}
+
 provider "azurerm" {
-    version = "~>2.12.0"
-    features {}
+	features {}
 }
 
 // the render network

--- a/src/terraform/examples/HPC Cache/azureblobfiler/main.tf
+++ b/src/terraform/examples/HPC Cache/azureblobfiler/main.tf
@@ -35,7 +35,7 @@ locals {
     // storage details
     storage_resource_group_name = "storage_resource_group"
     // create a globally unique name for the storage account
-    storage_account_name = "gdgdgdgdgdg"
+    storage_account_name = ""
     avere_storage_container_name = "hpccache"
 
     // per the hpc cache documentation: https://docs.microsoft.com/en-us/azure/hpc-cache/hpc-cache-add-storage

--- a/src/terraform/examples/HPC Cache/cachewarmer/1.networkandfiler/main.tf
+++ b/src/terraform/examples/HPC Cache/cachewarmer/1.networkandfiler/main.tf
@@ -18,9 +18,17 @@ locals {
     filer_size = "Standard_D2s_v3" 
 }
 
+terraform {
+	required_providers {
+		azurerm = {
+			source  = "hashicorp/azurerm"
+			version = "~>2.12.0"
+		}
+	}
+}
+
 provider "azurerm" {
-    version = "~>2.12.0"
-    features {}
+	features {}
 }
 
 // the render network

--- a/src/terraform/examples/HPC Cache/cachewarmer/2.jumpbox/main.tf
+++ b/src/terraform/examples/HPC Cache/cachewarmer/2.jumpbox/main.tf
@@ -21,9 +21,17 @@ locals {
   hpccache_network_resource_group_name = ""
 }
 
+terraform {
+	required_providers {
+		azurerm = {
+			source  = "hashicorp/azurerm"
+			version = "~>2.12.0"
+		}
+	}
+}
+
 provider "azurerm" {
-    version = "~>2.12.0"
-    features {}
+	features {}
 }
 
 module "jumpbox" {

--- a/src/terraform/examples/HPC Cache/cachewarmer/3.hpccacheandcachewarmer/main.tf
+++ b/src/terraform/examples/HPC Cache/cachewarmer/3.hpccacheandcachewarmer/main.tf
@@ -49,9 +49,17 @@ locals {
   jumpbox_username = ""
 }
 
+terraform {
+	required_providers {
+		azurerm = {
+			source  = "hashicorp/azurerm"
+			version = "~>2.12.0"
+		}
+	}
+}
+
 provider "azurerm" {
-    version = "~>2.12.0"
-    features {}
+	features {}
 }
 
 resource "azurerm_storage_account" "storage" {

--- a/src/terraform/examples/HPC Cache/dnsserver/main.tf
+++ b/src/terraform/examples/HPC Cache/dnsserver/main.tf
@@ -40,9 +40,17 @@ locals {
     onprem_filer_fqdn           = "nfs1.rendering.com" // the name of the filer to spoof
 }
 
+terraform {
+	required_providers {
+		azurerm = {
+			source  = "hashicorp/azurerm"
+			version = "~>2.12.0"
+		}
+	}
+}
+
 provider "azurerm" {
-    version = "~>2.12.0"
-    features {}
+	features {}
 }
 
 data "azurerm_subnet" "cachesubnet" {

--- a/src/terraform/examples/HPC Cache/hammerspace/main.tf
+++ b/src/terraform/examples/HPC Cache/hammerspace/main.tf
@@ -86,9 +86,17 @@ locals {
     hammerspace_filer_nfs_export_path = "/data"
 }
 
+terraform {
+	required_providers {
+		azurerm = {
+			source  = "hashicorp/azurerm"
+			version = "~>2.12.0"
+		}
+	}
+}
+
 provider "azurerm" {
-    version = "~>2.12.0"
-    features {}
+	features {}
 }
 
 // the render network

--- a/src/terraform/examples/HPC Cache/netapp-across-region/main.tf
+++ b/src/terraform/examples/HPC Cache/netapp-across-region/main.tf
@@ -46,9 +46,17 @@ locals {
     usage_model = "WRITE_AROUND"
 }
 
+terraform {
+	required_providers {
+		azurerm = {
+			source  = "hashicorp/azurerm"
+			version = "~>2.12.0"
+		}
+	}
+}
+
 provider "azurerm" {
-    version = "~>2.12.0"
-    features {}
+	features {}
 }
 
 ////////////////////////////////////////////////////////////////

--- a/src/terraform/examples/HPC Cache/netapp/main.tf
+++ b/src/terraform/examples/HPC Cache/netapp/main.tf
@@ -41,9 +41,17 @@ locals {
     volume_storage_quota_in_gb = 100
 }
 
+terraform {
+	required_providers {
+		azurerm = {
+			source  = "hashicorp/azurerm"
+			version = "~>2.12.0"
+		}
+	}
+}
+
 provider "azurerm" {
-    version = "~>2.12.0"
-    features {}
+	features {}
 }
 
 // the render network

--- a/src/terraform/examples/HPC Cache/no-filers/README.md
+++ b/src/terraform/examples/HPC Cache/no-filers/README.md
@@ -1,6 +1,6 @@
 # HPC Cache Deployment with no Filers
 
-This examples configures a render network, controller, and HPC Cache without any filers as shown in the diagram below:
+This example configures a render network and HPC Cache without any filers as shown in the diagram below:
 
 ![The architecture](../../../../../docs/images/terraform/nofiler-hpcc.png)
 

--- a/src/terraform/examples/HPC Cache/no-filers/main.tf
+++ b/src/terraform/examples/HPC Cache/no-filers/main.tf
@@ -27,9 +27,17 @@ locals {
     cache_name = "uniquename"
 }
 
+terraform {
+	required_providers {
+		azurerm = {
+			source  = "hashicorp/azurerm"
+			version = "~>2.12.0"
+		}
+	}
+}
+
 provider "azurerm" {
-    version = "~>2.12.0"
-    features {}
+	features {}
 }
 
 // the render network

--- a/src/terraform/examples/HPC Cache/vdbench/azureblobfiler/main.tf
+++ b/src/terraform/examples/HPC Cache/vdbench/azureblobfiler/main.tf
@@ -69,9 +69,17 @@ locals {
     open_external_sources = ["*"]
 }
 
+terraform {
+	required_providers {
+		azurerm = {
+			source  = "hashicorp/azurerm"
+			version = "~>2.12.0"
+		}
+	}
+}
+
 provider "azurerm" {
-    version = "~>2.12.0"
-    features {}
+	features {}
 }
 
 resource "azurerm_resource_group" "hpc_cache_rg" {

--- a/src/terraform/examples/HPC Cache/vdbench/nfsfiler/main.tf
+++ b/src/terraform/examples/HPC Cache/vdbench/nfsfiler/main.tf
@@ -57,9 +57,17 @@ locals {
     open_external_sources = ["*"]
 }
 
+terraform {
+	required_providers {
+		azurerm = {
+			source  = "hashicorp/azurerm"
+			version = "~>2.12.0"
+		}
+	}
+}
+
 provider "azurerm" {
-    version = "~>2.12.0"
-    features {}
+	features {}
 }
 
 resource "azurerm_resource_group" "hpc_cache_rg" {

--- a/src/terraform/examples/HPC Cache/vmss/main.tf
+++ b/src/terraform/examples/HPC Cache/vmss/main.tf
@@ -61,9 +61,17 @@ locals {
     open_external_sources = ["*"]
 }
 
+terraform {
+	required_providers {
+		azurerm = {
+			source  = "hashicorp/azurerm"
+			version = "~>2.12.0"
+		}
+	}
+}
+
 provider "azurerm" {
-    version = "~>2.12.0"
-    features {}
+	features {}
 }
 
 // the render network

--- a/src/terraform/examples/azcopysync/main.tf
+++ b/src/terraform/examples/azcopysync/main.tf
@@ -13,9 +13,17 @@ locals {
     container_name = "previz"
 }
 
+terraform {
+	required_providers {
+		azurerm = {
+			source  = "hashicorp/azurerm"
+			version = "~>2.12.0"
+		}
+	}
+}
+
 provider "azurerm" {
-    version = "~>2.12.0"
-    features {}
+	features {}
 }
 
 resource "azurerm_resource_group" "rg" {

--- a/src/terraform/examples/centos/cycle/main.tf
+++ b/src/terraform/examples/centos/cycle/main.tf
@@ -23,9 +23,17 @@ locals {
   vnet_resource_group = ""
 }
 
+terraform {
+	required_providers {
+		azurerm = {
+			source  = "hashicorp/azurerm"
+			version = "~>2.12.0"
+		}
+	}
+}
+
 provider "azurerm" {
-  version = "~>2.12.0"
-  features {}
+	features {}
 }
 
 resource "azurerm_resource_group" "vm" {

--- a/src/terraform/examples/centos/main.tf
+++ b/src/terraform/examples/centos/main.tf
@@ -33,9 +33,17 @@ locals {
     cloud_init_file = templatefile("${path.module}/cloud-init.tpl", { install_script = local.script_file_b64, search_domain = local.search_domain})
 }
 
+terraform {
+	required_providers {
+		azurerm = {
+			source  = "hashicorp/azurerm"
+			version = "~>2.12.0"
+		}
+	}
+}
+
 provider "azurerm" {
-    version = "~>2.12.0"
-    features {}
+	features {}
 }
 
 data "azurerm_subnet" "vnet" {

--- a/src/terraform/examples/centos/stockimage/main.tf
+++ b/src/terraform/examples/centos/stockimage/main.tf
@@ -39,9 +39,17 @@ locals {
     }
 }
 
+terraform {
+	required_providers {
+		azurerm = {
+			source  = "hashicorp/azurerm"
+			version = "~>2.12.0"
+		}
+	}
+}
+
 provider "azurerm" {
-    version = "~>2.12.0"
-    features {}
+	features {}
 }
 
 resource "azurerm_resource_group" "main" {

--- a/src/terraform/examples/centos/vmss/main.tf
+++ b/src/terraform/examples/centos/vmss/main.tf
@@ -37,9 +37,17 @@ locals {
     cloud_init_file = templatefile("${path.module}/../cloud-init.tpl", { install_script = local.script_file_b64, search_domain = local.search_domain})
 }
 
+terraform {
+	required_providers {
+		azurerm = {
+			source  = "hashicorp/azurerm"
+			version = "~>2.12.0"
+		}
+	}
+}
+
 provider "azurerm" {
-    version = "~>2.12.0"
-    features {}
+	features {}
 }
 
 data "azurerm_subnet" "vnet" {

--- a/src/terraform/examples/centosgridgpu/centosimage/main.tf
+++ b/src/terraform/examples/centosgridgpu/centosimage/main.tf
@@ -26,9 +26,17 @@ locals {
     search_domain               = ""
 }
 
+terraform {
+	required_providers {
+		azurerm = {
+			source  = "hashicorp/azurerm"
+			version = "~>2.12.0"
+		}
+	}
+}
+
 provider "azurerm" {
-    version = "~>2.12.0"
-    features {}
+	features {}
 }
 
 resource "azurerm_resource_group" "centosgridgpu" {

--- a/src/terraform/examples/centosgridgpu/main.tf
+++ b/src/terraform/examples/centosgridgpu/main.tf
@@ -25,9 +25,17 @@ locals {
     search_domain = ""
 }
 
+terraform {
+	required_providers {
+		azurerm = {
+			source  = "hashicorp/azurerm"
+			version = "~>2.12.0"
+		}
+	}
+}
+
 provider "azurerm" {
-    version = "~>2.12.0"
-    features {}
+	features {}
 }
 
 resource "azurerm_resource_group" "centosgridgpu" {

--- a/src/terraform/examples/dnsserver/main.tf
+++ b/src/terraform/examples/dnsserver/main.tf
@@ -51,9 +51,17 @@ locals {
     open_external_sources = ["*"]
 }
 
+terraform {
+	required_providers {
+		azurerm = {
+			source  = "hashicorp/azurerm"
+			version = "~>2.12.0"
+		}
+	}
+}
+
 provider "azurerm" {
-    version = "~>2.12.0"
-    features {}
+	features {}
 }
 
 // the render network

--- a/src/terraform/examples/dnsserver/standalone/main.tf
+++ b/src/terraform/examples/dnsserver/standalone/main.tf
@@ -27,9 +27,17 @@ locals {
     avere_ip_addr_count = 3
 }
 
+terraform {
+	required_providers {
+		azurerm = {
+			source  = "hashicorp/azurerm"
+			version = "~>2.12.0"
+		}
+	}
+}
+
 provider "azurerm" {
-    version = "~>2.12.0"
-    features {}
+	features {}
 }
 
 module "dnsserver" {

--- a/src/terraform/examples/hammerspace-multi-region/0.network/fourthregion/main.tf
+++ b/src/terraform/examples/hammerspace-multi-region/0.network/fourthregion/main.tf
@@ -25,9 +25,17 @@ locals {
     dns_servers = null // set this to the dc, for example ["10.0.3.254"] could be use for domain controller
 }
 
+terraform {
+	required_providers {
+		azurerm = {
+			source  = "hashicorp/azurerm"
+			version = "~>2.12.0"
+		}
+	}
+}
+
 provider "azurerm" {
-    version = "~>2.12.0"
-    features {}
+	features {}
 }
 
 ////////////////////////////////////////////////////////////////

--- a/src/terraform/examples/hammerspace-multi-region/0.network/main.tf
+++ b/src/terraform/examples/hammerspace-multi-region/0.network/main.tf
@@ -20,9 +20,17 @@ locals {
     dns_servers = null // set this to the dc, for example ["10.0.3.254"] could be use for domain controller
 }
 
+terraform {
+	required_providers {
+		azurerm = {
+			source  = "hashicorp/azurerm"
+			version = "~>2.12.0"
+		}
+	}
+}
+
 provider "azurerm" {
-    version = "~>2.12.0"
-    features {}
+	features {}
 }
 
 ////////////////////////////////////////////////////////////////

--- a/src/terraform/examples/hammerspace-multi-region/1.windowsdc/main.tf
+++ b/src/terraform/examples/hammerspace-multi-region/1.windowsdc/main.tf
@@ -43,9 +43,17 @@ locals {
   }
 }
 
+terraform {
+	required_providers {
+		azurerm = {
+			source  = "hashicorp/azurerm"
+			version = "~>2.12.0"
+		}
+	}
+}
+
 provider "azurerm" {
-  version = "~>2.12.0"
-  features {}
+	features {}
 }
 
 resource "azurerm_resource_group" "win" {

--- a/src/terraform/examples/hammerspace-multi-region/2.hammerspace/fourthregion/main.tf
+++ b/src/terraform/examples/hammerspace-multi-region/2.hammerspace/fourthregion/main.tf
@@ -81,9 +81,17 @@ locals {
     dns_servers = null // set this to the dc, for example ["10.0.3.254"] could be use for domain controller
 }
 
+terraform {
+	required_providers {
+		azurerm = {
+			source  = "hashicorp/azurerm"
+			version = "~>2.12.0"
+		}
+	}
+}
+
 provider "azurerm" {
-    version = "~>2.12.0"
-    features {}
+	features {}
 }
 
 ////////////////////////////////////////////////////////////////

--- a/src/terraform/examples/hammerspace-multi-region/2.hammerspace/main.tf
+++ b/src/terraform/examples/hammerspace-multi-region/2.hammerspace/main.tf
@@ -149,9 +149,17 @@ locals {
     dns_servers = null // set this to the dc, for example ["10.0.3.254"] could be use for domain controller
 }
 
+terraform {
+	required_providers {
+		azurerm = {
+			source  = "hashicorp/azurerm"
+			version = "~>2.12.0"
+		}
+	}
+}
+
 provider "azurerm" {
-    version = "~>2.12.0"
-    features {}
+	features {}
 }
 
 ////////////////////////////////////////////////////////////////

--- a/src/terraform/examples/hammerspace-multi-region/3.cache/main.tf
+++ b/src/terraform/examples/hammerspace-multi-region/3.cache/main.tf
@@ -64,9 +64,17 @@ locals {
     open_external_sources = ["*"]
 }
 
+terraform {
+	required_providers {
+		azurerm = {
+			source  = "hashicorp/azurerm"
+			version = "~>2.12.0"
+		}
+	}
+}
+
 provider "azurerm" {
-    version = "~>2.12.0"
-    features {}
+	features {}
 }
 
 resource "azurerm_storage_account" "storage" {

--- a/src/terraform/examples/hammerspace-multi-region/4.windowsclient/main.tf
+++ b/src/terraform/examples/hammerspace-multi-region/4.windowsclient/main.tf
@@ -37,9 +37,17 @@ locals {
     powershell_script = file("${path.module}/../../setupMachine.ps1")
 }
 
+terraform {
+	required_providers {
+		azurerm = {
+			source  = "hashicorp/azurerm"
+			version = "~>2.12.0"
+		}
+	}
+}
+
 provider "azurerm" {
-  version = "~>2.12.0"
-  features {}
+	features {}
 }
 
 resource "azurerm_resource_group" "win" {

--- a/src/terraform/examples/hammerspace/main.tf
+++ b/src/terraform/examples/hammerspace/main.tf
@@ -67,9 +67,17 @@ locals {
     nfs_export_path = "/data"
 }
 
+terraform {
+	required_providers {
+		azurerm = {
+			source  = "hashicorp/azurerm"
+			version = "~>2.12.0"
+		}
+	}
+}
+
 provider "azurerm" {
-    version = "~>2.12.0"
-    features {}
+	features {}
 }
 
 resource "azurerm_resource_group" "nfsfiler" {

--- a/src/terraform/examples/houdinienvironment/0.network/main.tf
+++ b/src/terraform/examples/houdinienvironment/0.network/main.tf
@@ -14,9 +14,17 @@ locals {
     dns_servers = null // set this to the dc, for example ["10.0.3.254"] could be use for domain controller
 }
 
+terraform {
+	required_providers {
+		azurerm = {
+			source  = "hashicorp/azurerm"
+			version = "~>2.12.0"
+		}
+	}
+}
+
 provider "azurerm" {
-    version = "~>2.12.0"
-    features {}
+	features {}
 }
 
 // the render network

--- a/src/terraform/examples/houdinienvironment/1.storage/blobstorage/main.tf
+++ b/src/terraform/examples/houdinienvironment/1.storage/blobstorage/main.tf
@@ -15,9 +15,17 @@ locals {
     vnet_resource_group = ""
 }
 
+terraform {
+	required_providers {
+		azurerm = {
+			source  = "hashicorp/azurerm"
+			version = "~>2.12.0"
+		}
+	}
+}
+
 provider "azurerm" {
-    version = "~>2.12.0"
-    features {}
+	features {}
 }
 
 resource "azurerm_resource_group" "storage" {

--- a/src/terraform/examples/houdinienvironment/1.storage/nfsfiler/main.tf
+++ b/src/terraform/examples/houdinienvironment/1.storage/nfsfiler/main.tf
@@ -26,9 +26,17 @@ locals {
     vnet_resource_group = ""
 }
 
+terraform {
+	required_providers {
+		azurerm = {
+			source  = "hashicorp/azurerm"
+			version = "~>2.12.0"
+		}
+	}
+}
+
 provider "azurerm" {
-    version = "~>2.12.0"
-    features {}
+	features {}
 }
 
 resource "azurerm_resource_group" "nfsfiler" {

--- a/src/terraform/examples/houdinienvironment/2.windowsstockvm/main.tf
+++ b/src/terraform/examples/houdinienvironment/2.windowsstockvm/main.tf
@@ -66,9 +66,17 @@ locals {
   }
 }
 
+terraform {
+	required_providers {
+		azurerm = {
+			source  = "hashicorp/azurerm"
+			version = "~>2.12.0"
+		}
+	}
+}
+
 provider "azurerm" {
-  version = "~>2.12.0"
-  features {}
+	features {}
 }
 
 resource "azurerm_resource_group" "win" {

--- a/src/terraform/examples/houdinienvironment/3.cache/main.tf
+++ b/src/terraform/examples/houdinienvironment/3.cache/main.tf
@@ -74,9 +74,17 @@ locals {
     cifs_share_ace = "" // leave empty for Everyone, otherwise example "azureuser(ALLOW,FULL) azureuser2(ALLOW,READ)"
 }
 
+terraform {
+	required_providers {
+		azurerm = {
+			source  = "hashicorp/azurerm"
+			version = "~>2.12.0"
+		}
+	}
+}
+
 provider "azurerm" {
-    version = "~>2.12.0"
-    features {}
+	features {}
 }
 
 // the vfxt controller

--- a/src/terraform/examples/houdinienvironment/4.rendernodes/vm/main.tf
+++ b/src/terraform/examples/houdinienvironment/4.rendernodes/vm/main.tf
@@ -37,9 +37,17 @@ locals {
     powershell_script = file("${path.module}/../../setupMachine.ps1")
 }
 
+terraform {
+	required_providers {
+		azurerm = {
+			source  = "hashicorp/azurerm"
+			version = "~>2.12.0"
+		}
+	}
+}
+
 provider "azurerm" {
-  version = "~>2.12.0"
-  features {}
+	features {}
 }
 
 resource "azurerm_resource_group" "win" {

--- a/src/terraform/examples/houdinienvironment/4.rendernodes/vmss/main.tf
+++ b/src/terraform/examples/houdinienvironment/4.rendernodes/vmss/main.tf
@@ -43,9 +43,17 @@ locals {
     powershell_script = file("${path.module}/../../setupMachine.ps1")
 }
 
+terraform {
+	required_providers {
+		azurerm = {
+			source  = "hashicorp/azurerm"
+			version = "~>2.12.0"
+		}
+	}
+}
+
 provider "azurerm" {
-    version = "~>2.12.0"
-    features {}
+	features {}
 }
 
 resource "azurerm_resource_group" "vmss" {

--- a/src/terraform/examples/houdinienvironment/4.rendernodes/vmssephemeral/main.tf
+++ b/src/terraform/examples/houdinienvironment/4.rendernodes/vmssephemeral/main.tf
@@ -46,9 +46,17 @@ locals {
     powershell_script = file("${path.module}/../../setupMachine.ps1")
 }
 
+terraform {
+	required_providers {
+		azurerm = {
+			source  = "hashicorp/azurerm"
+			version = "~>2.12.0"
+		}
+	}
+}
+
 provider "azurerm" {
-    version = "~>2.42.0"
-    features {}
+	features {}
 }
 
 resource "azurerm_resource_group" "vmss" {

--- a/src/terraform/examples/jumpbox/main.tf
+++ b/src/terraform/examples/jumpbox/main.tf
@@ -22,9 +22,17 @@ locals {
     build_vfxt_terraform_provider = true
 }
 
+terraform {
+	required_providers {
+		azurerm = {
+			source  = "hashicorp/azurerm"
+			version = "~>2.12.0"
+		}
+	}
+}
+
 provider "azurerm" {
-    version = "~>2.12.0"
-    features {}
+	features {}
 }
 
 // the render network

--- a/src/terraform/examples/nfsfiler/main.tf
+++ b/src/terraform/examples/nfsfiler/main.tf
@@ -35,9 +35,17 @@ locals {
     vm_size = "Standard_L32s_v2"
 }
 
+terraform {
+	required_providers {
+		azurerm = {
+			source  = "hashicorp/azurerm"
+			version = "~>2.12.0"
+		}
+	}
+}
+
 provider "azurerm" {
-    version = "~>2.12.0"
-    features {}
+	features {}
 }
 
 resource "azurerm_resource_group" "nfsfiler" {

--- a/src/terraform/examples/nfsfilerganesha/main.tf
+++ b/src/terraform/examples/nfsfilerganesha/main.tf
@@ -54,9 +54,17 @@ locals {
     caching = local.disk_size_gb > 4095 ? "None" : "ReadWrite"
 }
 
+terraform {
+	required_providers {
+		azurerm = {
+			source  = "hashicorp/azurerm"
+			version = "~>2.12.0"
+		}
+	}
+}
+
 provider "azurerm" {
-    version = "~>2.12.0"
-    features {}
+	features {}
 }
 
 resource "azurerm_resource_group" "nfsfiler" {

--- a/src/terraform/examples/nfsfilermd/main.tf
+++ b/src/terraform/examples/nfsfilermd/main.tf
@@ -55,9 +55,17 @@ locals {
     caching = local.disk_size_gb > 4095 ? "None" : "ReadWrite"
 }
 
+terraform {
+	required_providers {
+		azurerm = {
+			source  = "hashicorp/azurerm"
+			version = "~>2.12.0"
+		}
+	}
+}
+
 provider "azurerm" {
-    version = "~>2.12.0"
-    features {}
+	features {}
 }
 
 resource "azurerm_resource_group" "nfsfiler" {

--- a/src/terraform/examples/securedimage/main.tf
+++ b/src/terraform/examples/securedimage/main.tf
@@ -22,9 +22,17 @@ locals {
     image_name = "image_name"
 }
 
+terraform {
+	required_providers {
+		azurerm = {
+			source  = "hashicorp/azurerm"
+			version = "~>2.12.0"
+		}
+	}
+}
+
 provider "azurerm" {
-    version = "~>2.12.0"
-    features {}
+	features {}
 }
 
 data "azurerm_resource_group" "main" {

--- a/src/terraform/examples/securevnet/main.tf
+++ b/src/terraform/examples/securevnet/main.tf
@@ -25,9 +25,17 @@ locals {
     private_network_prefixes = ["10.0.0.0/8","172.16.0.0/12","192.168.0.0/16"]
 }
 
+terraform {
+	required_providers {
+		azurerm = {
+			source  = "hashicorp/azurerm"
+			version = "~>2.12.0"
+		}
+	}
+}
+
 provider "azurerm" {
-    version = "~>2.12.0"
-    features {}
+	features {}
 }
 
 resource "azurerm_resource_group" "render_rg" {

--- a/src/terraform/examples/vfxt/1-filer/main.tf
+++ b/src/terraform/examples/vfxt/1-filer/main.tf
@@ -45,9 +45,17 @@ locals {
     open_external_sources = ["*"]
 }
 
+terraform {
+	required_providers {
+		azurerm = {
+			source  = "hashicorp/azurerm"
+			version = "~>2.12.0"
+		}
+	}
+}
+
 provider "azurerm" {
-    version = "~>2.12.0"
-    features {}
+	features {}
 }
 
 // the render network

--- a/src/terraform/examples/vfxt/3-filers/main.tf
+++ b/src/terraform/examples/vfxt/3-filers/main.tf
@@ -44,9 +44,17 @@ locals {
     open_external_sources = ["*"]
 }
 
+terraform {
+	required_providers {
+		azurerm = {
+			source  = "hashicorp/azurerm"
+			version = "~>2.12.0"
+		}
+	}
+}
+
 provider "azurerm" {
-    version = "~>2.12.0"
-    features {}
+	features {}
 }
 
 // the render network

--- a/src/terraform/examples/vfxt/HoudiniOptimized/main.tf
+++ b/src/terraform/examples/vfxt/HoudiniOptimized/main.tf
@@ -44,9 +44,17 @@ locals {
     open_external_sources = ["*"]
 }
 
+terraform {
+	required_providers {
+		azurerm = {
+			source  = "hashicorp/azurerm"
+			version = "~>2.12.0"
+		}
+	}
+}
+
 provider "azurerm" {
-    version = "~>2.12.0"
-    features {}
+	features {}
 }
 
 // the render network

--- a/src/terraform/examples/vfxt/azureblobfiler/main.tf
+++ b/src/terraform/examples/vfxt/azureblobfiler/main.tf
@@ -40,9 +40,17 @@ locals {
     open_external_sources = ["*"]
 }
 
+terraform {
+	required_providers {
+		azurerm = {
+			source  = "hashicorp/azurerm"
+			version = "~>2.12.0"
+		}
+	}
+}
+
 provider "azurerm" {
-    version = "~>2.12.0"
-    features {}
+	features {}
 }
 
 // the render network

--- a/src/terraform/examples/vfxt/cachewarmer/1.networkandfiler/main.tf
+++ b/src/terraform/examples/vfxt/cachewarmer/1.networkandfiler/main.tf
@@ -25,9 +25,17 @@ locals {
     open_external_sources = ["*"]
 }
 
+terraform {
+	required_providers {
+		azurerm = {
+			source  = "hashicorp/azurerm"
+			version = "~>2.12.0"
+		}
+	}
+}
+
 provider "azurerm" {
-    version = "~>2.12.0"
-    features {}
+	features {}
 }
 
 // the render network

--- a/src/terraform/examples/vfxt/cachewarmer/2.vfxtcontroller/main.tf
+++ b/src/terraform/examples/vfxt/cachewarmer/2.vfxtcontroller/main.tf
@@ -25,9 +25,17 @@ locals {
   vfxt_network_resource_group_name = ""
 }
 
+terraform {
+	required_providers {
+		azurerm = {
+			source  = "hashicorp/azurerm"
+			version = "~>2.12.0"
+		}
+	}
+}
+
 provider "azurerm" {
-    version = "~>2.12.0"
-    features {}
+	features {}
 }
 
 // the vfxt controller

--- a/src/terraform/examples/vfxt/cachewarmer/3.vfxtandcachewarmer/main.tf
+++ b/src/terraform/examples/vfxt/cachewarmer/3.vfxtandcachewarmer/main.tf
@@ -39,9 +39,17 @@ locals {
   vfxt_resource_group_name = ""
 }
 
+terraform {
+	required_providers {
+		azurerm = {
+			source  = "hashicorp/azurerm"
+			version = "~>2.12.0"
+		}
+	}
+}
+
 provider "azurerm" {
-    version = "~>2.12.0"
-    features {}
+	features {}
 }
 
 resource "azurerm_storage_account" "storage" {

--- a/src/terraform/examples/vfxt/cloudworkstation/collaboratingcloudworkstation/main.tf
+++ b/src/terraform/examples/vfxt/cloudworkstation/collaboratingcloudworkstation/main.tf
@@ -47,9 +47,17 @@ locals {
     open_external_sources = ["*"]
 }
 
+terraform {
+	required_providers {
+		azurerm = {
+			source  = "hashicorp/azurerm"
+			version = "~>2.12.0"
+		}
+	}
+}
+
 provider "azurerm" {
-    version = "~>2.12.0"
-    features {}
+	features {}
 }
 
 // the render network

--- a/src/terraform/examples/vfxt/cloudworkstation/isolatedcloudworkstation/main.tf
+++ b/src/terraform/examples/vfxt/cloudworkstation/isolatedcloudworkstation/main.tf
@@ -47,9 +47,17 @@ locals {
     open_external_sources = ["*"]
 }
 
+terraform {
+	required_providers {
+		azurerm = {
+			source  = "hashicorp/azurerm"
+			version = "~>2.12.0"
+		}
+	}
+}
+
 provider "azurerm" {
-    version = "~>2.12.0"
-    features {}
+	features {}
 }
 
 // the render network

--- a/src/terraform/examples/vfxt/custom-vserver/main.tf
+++ b/src/terraform/examples/vfxt/custom-vserver/main.tf
@@ -49,9 +49,17 @@ locals {
     open_external_sources = ["*"]
 }
 
+terraform {
+	required_providers {
+		azurerm = {
+			source  = "hashicorp/azurerm"
+			version = "~>2.12.0"
+		}
+	}
+}
+
 provider "azurerm" {
-    version = "~>2.12.0"
-    features {}
+	features {}
 }
 
 // the render network

--- a/src/terraform/examples/vfxt/hammerspace/main.tf
+++ b/src/terraform/examples/vfxt/hammerspace/main.tf
@@ -90,9 +90,17 @@ locals {
     open_external_sources = ["*"]
 }
 
+terraform {
+	required_providers {
+		azurerm = {
+			source  = "hashicorp/azurerm"
+			version = "~>2.12.0"
+		}
+	}
+}
+
 provider "azurerm" {
-    version = "~>2.12.0"
-    features {}
+	features {}
 }
 
 // the render network

--- a/src/terraform/examples/vfxt/netapp-across-region/main.tf
+++ b/src/terraform/examples/vfxt/netapp-across-region/main.tf
@@ -52,9 +52,17 @@ locals {
     open_external_sources = ["*"]
 }
 
+terraform {
+	required_providers {
+		azurerm = {
+			source  = "hashicorp/azurerm"
+			version = "~>2.12.0"
+		}
+	}
+}
+
 provider "azurerm" {
-    version = "~>2.12.0"
-    features {}
+	features {}
 }
 
 ////////////////////////////////////////////////////////////////

--- a/src/terraform/examples/vfxt/netapp/main.tf
+++ b/src/terraform/examples/vfxt/netapp/main.tf
@@ -49,9 +49,17 @@ locals {
     open_external_sources = ["*"]
 }
 
+terraform {
+	required_providers {
+		azurerm = {
+			source  = "hashicorp/azurerm"
+			version = "~>2.12.0"
+		}
+	}
+}
+
 provider "azurerm" {
-    version = "~>2.12.0"
-    features {}
+	features {}
 }
 
 // the render network

--- a/src/terraform/examples/vfxt/no-filers/main.tf
+++ b/src/terraform/examples/vfxt/no-filers/main.tf
@@ -40,9 +40,17 @@ locals {
     open_external_sources = ["*"]
 }
 
+terraform {
+	required_providers {
+		azurerm = {
+			source  = "hashicorp/azurerm"
+			version = "~>2.12.0"
+		}
+	}
+}
+
 provider "azurerm" {
-    version = "~>2.12.0"
-    features {}
+	features {}
 }
 
 // the render network

--- a/src/terraform/examples/vfxt/opencue/new-storage/main.tf
+++ b/src/terraform/examples/vfxt/opencue/new-storage/main.tf
@@ -47,9 +47,17 @@ locals {
     open_external_sources = ["*"]
 }
 
+terraform {
+	required_providers {
+		azurerm = {
+			source  = "hashicorp/azurerm"
+			version = "~>2.12.0"
+		}
+	}
+}
+
 provider "azurerm" {
-    version = "~>2.12.0"
-    features {}
+	features {}
 }
 
 // the render network

--- a/src/terraform/examples/vfxt/opencue/pre-existing-azure-blob/main.tf
+++ b/src/terraform/examples/vfxt/opencue/pre-existing-azure-blob/main.tf
@@ -52,9 +52,17 @@ locals {
     open_external_sources = ["*"]
 }
 
+terraform {
+	required_providers {
+		azurerm = {
+			source  = "hashicorp/azurerm"
+			version = "~>2.12.0"
+		}
+	}
+}
+
 provider "azurerm" {
-    version = "~>2.12.0"
-    features {}
+	features {}
 }
 
 // the render network

--- a/src/terraform/examples/vfxt/pipeline/centos/main.tf
+++ b/src/terraform/examples/vfxt/pipeline/centos/main.tf
@@ -29,9 +29,17 @@ locals {
     }
 }
 
+terraform {
+	required_providers {
+		azurerm = {
+			source  = "hashicorp/azurerm"
+			version = "~>2.12.0"
+		}
+	}
+}
+
 provider "azurerm" {
-    version = "~>2.12.0"
-    features {}
+	features {}
 }
 
 resource "azurerm_resource_group" "main" {

--- a/src/terraform/examples/vfxt/pipeline/ubuntu/main.tf
+++ b/src/terraform/examples/vfxt/pipeline/ubuntu/main.tf
@@ -29,9 +29,17 @@ locals {
     }
 }
 
+terraform {
+	required_providers {
+		azurerm = {
+			source  = "hashicorp/azurerm"
+			version = "~>2.12.0"
+		}
+	}
+}
+
 provider "azurerm" {
-    version = "~>2.12.0"
-    features {}
+	features {}
 }
 
 resource "azurerm_resource_group" "main" {

--- a/src/terraform/examples/vfxt/proxy/main.tf
+++ b/src/terraform/examples/vfxt/proxy/main.tf
@@ -57,9 +57,17 @@ locals {
     open_external_sources = ["*"]
 }
 
+terraform {
+	required_providers {
+		azurerm = {
+			source  = "hashicorp/azurerm"
+			version = "~>2.12.0"
+		}
+	}
+}
+
 provider "azurerm" {
-    version = "~>2.12.0"
-    features {}
+	features {}
 }
 
 // the render network

--- a/src/terraform/examples/vfxt/test-cluster/main.tf
+++ b/src/terraform/examples/vfxt/test-cluster/main.tf
@@ -39,9 +39,17 @@ locals {
     open_external_sources = ["*"]
 }
 
+terraform {
+	required_providers {
+		azurerm = {
+			source  = "hashicorp/azurerm"
+			version = "~>2.12.0"
+		}
+	}
+}
+
 provider "azurerm" {
-    version = "~>2.12.0"
-    features {}
+	features {}
 }
 
 // the render network

--- a/src/terraform/examples/vfxt/user-assigned-managed-identity/main.tf
+++ b/src/terraform/examples/vfxt/user-assigned-managed-identity/main.tf
@@ -58,9 +58,16 @@ locals {
     open_external_sources = ["*"]
 }
 
-provider "azurerm" {
-    version = "~>2.12.0"
+terraform {
+	required_providers {
+		azurerm = {
+			source  = "hashicorp/azurerm"
+			version = "~>2.12.0"
+		}
+	}
+}
 
+provider "azurerm" {
     subscription_id = local.subscription_id
     client_id       = local.client_id
     client_secret   = local.client_secret

--- a/src/terraform/examples/vfxt/vdbench/azureblobfiler/main.tf
+++ b/src/terraform/examples/vfxt/vdbench/azureblobfiler/main.tf
@@ -42,9 +42,17 @@ locals {
     open_external_sources = ["*"]
 }
 
+terraform {
+	required_providers {
+		azurerm = {
+			source  = "hashicorp/azurerm"
+			version = "~>2.12.0"
+		}
+	}
+}
+
 provider "azurerm" {
-    version = "~>2.12.0"
-    features {}
+	features {}
 }
 
 // the render network

--- a/src/terraform/examples/vfxt/vdbench/main.tf
+++ b/src/terraform/examples/vfxt/vdbench/main.tf
@@ -53,9 +53,17 @@ locals {
     mount_target = "/data"
 }
 
+terraform {
+	required_providers {
+		azurerm = {
+			source  = "hashicorp/azurerm"
+			version = "~>2.12.0"
+		}
+	}
+}
+
 provider "azurerm" {
-    version = "~>2.12.0"
-    features {}
+	features {}
 }
 
 // the vdbench module

--- a/src/terraform/examples/vfxt/vdbench/nfsfiler/main.tf
+++ b/src/terraform/examples/vfxt/vdbench/nfsfiler/main.tf
@@ -46,9 +46,17 @@ locals {
     open_external_sources = ["*"]
 }
 
+terraform {
+	required_providers {
+		azurerm = {
+			source  = "hashicorp/azurerm"
+			version = "~>2.12.0"
+		}
+	}
+}
+
 provider "azurerm" {
-    version = "~>2.12.0"
-    features {}
+	features {}
 }
 
 // the render network

--- a/src/terraform/examples/vfxt/vfxt-only/main.tf
+++ b/src/terraform/examples/vfxt/vfxt-only/main.tf
@@ -45,9 +45,17 @@ locals {
     alternative_resource_groups = []
 }
 
+terraform {
+	required_providers {
+		azurerm = {
+			source  = "hashicorp/azurerm"
+			version = "~>2.12.0"
+		}
+	}
+}
+
 provider "azurerm" {
-    version = "~>2.12.0"
-    features {}
+	features {}
 }
 
 // the vfxt controller

--- a/src/terraform/examples/vfxt/vfxt-only/simulated_environment/main.tf
+++ b/src/terraform/examples/vfxt/vfxt-only/simulated_environment/main.tf
@@ -24,9 +24,17 @@ locals {
     open_external_sources = ["*"]
 }
 
+terraform {
+	required_providers {
+		azurerm = {
+			source  = "hashicorp/azurerm"
+			version = "~>2.12.0"
+		}
+	}
+}
+
 provider "azurerm" {
-    version = "~>2.12.0"
-    features {}
+	features {}
 }
 
 // the render network

--- a/src/terraform/examples/vfxt/vmss/main.tf
+++ b/src/terraform/examples/vfxt/vmss/main.tf
@@ -52,9 +52,17 @@ locals {
     open_external_sources = ["*"]
 }
 
+terraform {
+	required_providers {
+		azurerm = {
+			source  = "hashicorp/azurerm"
+			version = "~>2.12.0"
+		}
+	}
+}
+
 provider "azurerm" {
-    version = "~>2.12.0"
-    features {}
+	features {}
 }
 
 // the render network

--- a/src/terraform/examples/vmss-rendering/main.tf
+++ b/src/terraform/examples/vmss-rendering/main.tf
@@ -21,9 +21,17 @@ locals {
     use_ephemeral_os_disk = true
 }
 
+terraform {
+	required_providers {
+		azurerm = {
+			source  = "hashicorp/azurerm"
+			version = "~>2.12.0"
+		}
+	}
+}
+
 provider "azurerm" {
-    version = "~>2.12.0"
-    features {}
+	features {}
 }
 
 resource "azurerm_resource_group" "vmss" {

--- a/src/terraform/examples/windows/client-ps-cse/main.tf
+++ b/src/terraform/examples/windows/client-ps-cse/main.tf
@@ -21,9 +21,17 @@ locals {
   powershell_script = templatefile("${path.module}/setupMachine.ps1", {})
 }
 
+terraform {
+	required_providers {
+		azurerm = {
+			source  = "hashicorp/azurerm"
+			version = "~>2.12.0"
+		}
+	}
+}
+
 provider "azurerm" {
-  version = "~>2.12.0"
-  features {}
+	features {}
 }
 
 resource "azurerm_resource_group" "win" {

--- a/src/terraform/examples/windowsgridgpu/main.tf
+++ b/src/terraform/examples/windowsgridgpu/main.tf
@@ -31,9 +31,17 @@ locals {
     virtual_network_subnet_name    = "jumpbox"  
 }
 
+terraform {
+	required_providers {
+		azurerm = {
+			source  = "hashicorp/azurerm"
+			version = "~>2.12.0"
+		}
+	}
+}
+
 provider "azurerm" {
-    version = "~>2.12.0"
-    features {}
+	features {}
 }
 
 resource "azurerm_resource_group" "windowsgridgpu" {

--- a/src/terraform/examples/windowsgridgpu/winimage/main.tf
+++ b/src/terraform/examples/windowsgridgpu/winimage/main.tf
@@ -33,9 +33,17 @@ locals {
     virtual_network_subnet_name    = "jumpbox"
 }
 
+terraform {
+	required_providers {
+		azurerm = {
+			source  = "hashicorp/azurerm"
+			version = "~>2.12.0"
+		}
+	}
+}
+
 provider "azurerm" {
-    version = "~>2.12.0"
-    features {}
+	features {}
 }
 
 resource "azurerm_resource_group" "windowsgridgpu" {

--- a/src/terraform/examples/wireguard/main.tf
+++ b/src/terraform/examples/wireguard/main.tf
@@ -34,9 +34,17 @@ locals {
     jb_cloud_init_file = templatefile("${path.module}/cloud-init.tpl", { installcmd = local.jb_script_file_b64 })
 }
 
+terraform {
+	required_providers {
+		azurerm = {
+			source  = "hashicorp/azurerm"
+			version = "~>2.12.0"
+		}
+	}
+}
+
 provider "azurerm" {
-    version = "~>2.12.0"
-    features {}
+	features {}
 }
 
 ###########################################################


### PR DESCRIPTION
Moved AzureRM provider required version property into Terraform "required_providers" block to resolve init / validate warnings.