### PR TITLE
Fix error: var.web_ui_password is list of string with 1 element

### DIFF
--- a/src/terraform/modules/hammerspace/anvil-run-once-configure/main.tf
+++ b/src/terraform/modules/hammerspace/anvil-run-once-configure/main.tf
@@ -2,7 +2,7 @@
 locals {
   script_file_b64 = base64gzip(replace(file("${path.module}/configure-anvil.py"), "\r", ""))
 
-  command = "mkdir -p /opt && touch /opt/configure-anvil.py && echo ${local.script_file_b64} | base64 -d | gunzip > /opt/configure-anvil.py && python2 /opt/configure-anvil.py ${var.anvil_data_cluster_ip} ${var.web_ui_password} ${var.dsx_count}  -a '${var.ad_domain}' -u '${var.ad_user}' -p '${var.ad_user_password}' -n '${var.local_site_name}' -s '${var.nfs_export_path}' --azure-account '${var.azure_storage_account}' --azure-account-key '${var.azure_storage_account_key}' --azure-account-container '${var.azure_storage_account_container}' "
+  command = "mkdir -p /opt && touch /opt/configure-anvil.py && echo ${local.script_file_b64} | base64 -d | gunzip > /opt/configure-anvil.py && python2 /opt/configure-anvil.py ${var.anvil_data_cluster_ip} ${var.web_ui_password[0]} ${var.dsx_count}  -a '${var.ad_domain}' -u '${var.ad_user}' -p '${var.ad_user_password}' -n '${var.local_site_name}' -s '${var.nfs_export_path}' --azure-account '${var.azure_storage_account}' --azure-account-key '${var.azure_storage_account_key}' --azure-account-container '${var.azure_storage_account_container}' "
 }
 
 resource "azurerm_virtual_machine_extension" "cse" {


### PR DESCRIPTION
Fixes the following error when deploying:

│ Error: Invalid template interpolation value
│
│   on .terraform/modules/anvil_configure/src/terraform/modules/hammerspace/anvil-run-once-configure/main.tf line 5, in locals:
│    5:   command = "mkdir -p /opt && touch /opt/configure-anvil.py && echo ${local.script_file_b64} | base64 -d | gunzip > /opt/configure-anvil.py && python2 /opt/configure-anvil.py ${var.anvil_data_cluster_ip} ${var.web_ui_password} ${var.dsx_count}  -a '${var.ad_domain}' -u '${var.ad_user}' -p '${var.ad_user_password}' -n '${var.local_site_name}' -s '${var.nfs_export_path}' --azure-account '${var.azure_storage_account}' --azure-account-key '${var.azure_storage_account_key}' --azure-account-container '${var.azure_storage_account_container}' "
│     ├────────────────
│     │ var.web_ui_password is list of string with 1 element
│
│ Cannot include the given value in a string template: string required.