### PR TITLE
Fix for Error: Unsupported attribute in Hammerspace example

### DIFF
--- a/src/terraform/examples/hammerspace-multi-region/2.hammerspace/main.tf
+++ b/src/terraform/examples/hammerspace-multi-region/2.hammerspace/main.tf
@@ -244,7 +244,7 @@ module "anvil_configure1" {
   source                       = "github.com/Azure/Avere/src/terraform/modules/hammerspace/anvil-run-once-configure"
   anvil_arm_virtual_machine_id = length(module.anvil1.arm_virtual_machine_ids) == 0 ? "" : module.anvil1.arm_virtual_machine_ids[0]
   anvil_data_cluster_ip        = module.anvil1.anvil_data_cluster_ip
-  web_ui_password              = module.anvil1.web_ui_password
+  web_ui_password              = module.anvil1.web_ui_password[0]
   dsx_count                    = local.region1_configuration.dsx_instance_count
   anvil_hostname               = length(module.anvil1.anvil_host_names) == 0 ? "" : module.anvil1.anvil_host_names[0]
 
@@ -323,7 +323,7 @@ module "anvil_configure2" {
   source                       = "github.com/Azure/Avere/src/terraform/modules/hammerspace/anvil-run-once-configure"
   anvil_arm_virtual_machine_id = length(module.anvil2.arm_virtual_machine_ids) == 0 ? "" : module.anvil2.arm_virtual_machine_ids[0]
   anvil_data_cluster_ip        = module.anvil2.anvil_data_cluster_ip
-  web_ui_password              = module.anvil2.web_ui_password
+  web_ui_password              = module.anvil2.web_ui_password[0]
   dsx_count                    = local.region2_configuration.dsx_instance_count
   anvil_hostname               = length(module.anvil2.anvil_host_names) == 0 ? "" : module.anvil2.anvil_host_names[0]
 
@@ -402,7 +402,7 @@ module "anvil_configure3" {
   source                       = "github.com/Azure/Avere/src/terraform/modules/hammerspace/anvil-run-once-configure"
   anvil_arm_virtual_machine_id = length(module.anvil3.arm_virtual_machine_ids) == 0 ? "" : module.anvil3.arm_virtual_machine_ids[0]
   anvil_data_cluster_ip        = module.anvil3.anvil_data_cluster_ip
-  web_ui_password              = module.anvil3.web_ui_password
+  web_ui_password              = module.anvil3.web_ui_password[0]
   dsx_count                    = local.region3_configuration.dsx_instance_count
   anvil_hostname               = length(module.anvil3.anvil_host_names) == 0 ? "" : module.anvil3.anvil_host_names[0]
 
@@ -426,7 +426,7 @@ output "hammerspace_webui_username" {
 }
 
 output "hammerspace_webui_password_1" {
-  value = module.anvil1.web_ui_password
+  value = module.anvil1.web_ui_password[0]
 }
 
 output "anvil_data_cluster_ip_1" {
@@ -438,7 +438,7 @@ output "nfs_mountable_ips_1" {
 }
 
 output "hammerspace_webui_password_2" {
-  value = module.anvil2.web_ui_password
+  value = module.anvil2.web_ui_password[0]
 }
 
 output "anvil_data_cluster_ip_2" {
@@ -450,7 +450,7 @@ output "nfs_mountable_ips_2" {
 }
 
 output "hammerspace_webui_password_3" {
-  value = module.anvil3.web_ui_password
+  value = module.anvil3.web_ui_password[0]
 }
 
 output "anvil_data_cluster_ip_3" {

--- a/src/terraform/examples/hammerspace/main.tf
+++ b/src/terraform/examples/hammerspace/main.tf
@@ -189,12 +189,8 @@ output "anvil_data_cluster_ip" {
   value = module.anvil.anvil_data_cluster_ip
 }
 
-output "anvil_data_cluster_data0_ip" {
-  value = module.anvil.anvil_data_cluster_data0_ip
-}
-
-output "anvil_data_cluster_data1_ip" {
-  value = module.anvil.anvil_data_cluster_data1_ip
+output "anvil_data_cluster_data_ips" {
+  value = module.anvil.anvil_data_cluster_data_ips
 }
 
 output "nfs_mountable_ips" {

--- a/src/terraform/examples/hammerspace/main.tf
+++ b/src/terraform/examples/hammerspace/main.tf
@@ -163,7 +163,7 @@ module "anvil_configure" {
   source                       = "github.com/Azure/Avere/src/terraform/modules/hammerspace/anvil-run-once-configure"
   anvil_arm_virtual_machine_id = length(module.anvil.arm_virtual_machine_ids) == 0 ? "" : module.anvil.arm_virtual_machine_ids[0]
   anvil_data_cluster_ip        = module.anvil.anvil_data_cluster_ip
-  web_ui_password              = module.anvil.web_ui_password
+  web_ui_password              = module.anvil.web_ui_password[0]
   dsx_count                    = local.region_configuration.dsx_instance_count
   nfs_export_path              = local.nfs_export_path
   anvil_hostname               = length(module.anvil.anvil_host_names) == 0 ? "" : module.anvil.anvil_host_names[0]
@@ -182,7 +182,7 @@ output "hammerspace_webui_username" {
 }
 
 output "hammerspace_webui_password" {
-  value = module.anvil.web_ui_password
+  value = module.anvil.web_ui_password[0]
 }
 
 output "anvil_data_cluster_ip" {

--- a/src/terraform/examples/vfxt/hammerspace/main.tf
+++ b/src/terraform/examples/vfxt/hammerspace/main.tf
@@ -188,7 +188,7 @@ module "anvil_configure" {
   source                       = "github.com/Azure/Avere/src/terraform/modules/hammerspace/anvil-run-once-configure"
   anvil_arm_virtual_machine_id = length(module.anvil.arm_virtual_machine_ids) == 0 ? "" : module.anvil.arm_virtual_machine_ids[0]
   anvil_data_cluster_ip        = module.anvil.anvil_data_cluster_ip
-  web_ui_password              = module.anvil.web_ui_password
+  web_ui_password              = module.anvil.web_ui_password[0]
   dsx_count                    = local.region_configuration.dsx_instance_count
   nfs_export_path              = local.hammerspace_filer_nfs_export_path
   anvil_hostname               = length(module.anvil.anvil_host_names) == 0 ? "" : module.anvil.anvil_host_names[0]
@@ -277,7 +277,7 @@ output "hammerspace_webui_username" {
 }
 
 output "hammerspace_webui_password" {
-  value = module.anvil.web_ui_password
+  value = module.anvil.web_ui_password[0]
 }
 
 output "anvil_data_cluster_data_ips" {

--- a/src/terraform/modules/hammerspace/anvil-run-once-configure/main.tf
+++ b/src/terraform/modules/hammerspace/anvil-run-once-configure/main.tf
@@ -2,7 +2,7 @@
 locals {
   script_file_b64 = base64gzip(replace(file("${path.module}/configure-anvil.py"), "\r", ""))
 
-  command = "mkdir -p /opt && touch /opt/configure-anvil.py && echo ${local.script_file_b64} | base64 -d | gunzip > /opt/configure-anvil.py && python2 /opt/configure-anvil.py ${var.anvil_data_cluster_ip} ${var.web_ui_password[0]} ${var.dsx_count}  -a '${var.ad_domain}' -u '${var.ad_user}' -p '${var.ad_user_password}' -n '${var.local_site_name}' -s '${var.nfs_export_path}' --azure-account '${var.azure_storage_account}' --azure-account-key '${var.azure_storage_account_key}' --azure-account-container '${var.azure_storage_account_container}' "
+  command = "mkdir -p /opt && touch /opt/configure-anvil.py && echo ${local.script_file_b64} | base64 -d | gunzip > /opt/configure-anvil.py && python2 /opt/configure-anvil.py ${var.anvil_data_cluster_ip} ${var.web_ui_password} ${var.dsx_count}  -a '${var.ad_domain}' -u '${var.ad_user}' -p '${var.ad_user_password}' -n '${var.local_site_name}' -s '${var.nfs_export_path}' --azure-account '${var.azure_storage_account}' --azure-account-key '${var.azure_storage_account_key}' --azure-account-container '${var.azure_storage_account_container}' "
 }
 
 resource "azurerm_virtual_machine_extension" "cse" {


### PR DESCRIPTION
```
√ hammerspace $ terraform apply -auto-approve
╷
│ Error: Unsupported attribute
│
│   on main.tf line 195, in output "anvil_data_cluster_data0_ip":
│  195:   value = module.anvil.anvil_data_cluster_data0_ip
│     ├────────────────
│     │ module.anvil is a object, known only after apply
│
│ This object does not have an attribute named "anvil_data_cluster_data0_ip".
╵
╷
│ Error: Unsupported attribute
│
│   on main.tf line 199, in output "anvil_data_cluster_data1_ip":
│  199:   value = module.anvil.anvil_data_cluster_data1_ip
│     ├────────────────
│     │ module.anvil is a object, known only after apply
│
│ This object does not have an attribute named "anvil_data_cluster_data1_ip".
```