### PR TITLE
Create web pages for feature preview documentation

### DIFF
--- a/docs/previews/hpc-priming.html
+++ b/docs/previews/hpc-priming.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html class="no-js" lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>HPC Cache priming preview information</title>    
+<meta name="robots" content="noindex">
+</head>
+<body>
+    <h1>Azure HPC Cache priming - private preview documentation</h1>
+    <p><i><b>This information is intended only for participants in the private preview for the Priming feature in Azure HPC Cache. If you need help with non-preview features please contact <a href="https://docs.microsoft.com/azure/hpc-cache/hpc-cache-support-ticket">HPC Cache support</a>.</i></b></p>
+
+
+<h2>Under construction</h2>
+<p>This page is not yet populated.</p>
+
+    <p>© 2021 Microsoft Corporation. All rights reserved.</p>
+</body>
+</html>

--- a/docs/previews/preview-features.html
+++ b/docs/previews/preview-features.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html class="no-js" lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Preview feature documentation hub</title>    
+<meta name="robots" content="noindex">
+</head>
+<body>
+
+<h1>Preview feature documentation</h1>
+<p>The documentation in this section is intended only for private preview customers of specific Azure products. If you have questions, contact Azure sales.</p>
+
+<h2>Azure HPC Cache</h2>
+<ul>
+    <li><a href="hpc-priming.html">Cache priming feature</a> (September 2021) </li>
+</ul> 
+
+
+<p>© 2021 Microsoft Corporation. All rights reserved.</p>
+</body>
+</html>


### PR DESCRIPTION
Intent is to create a page that can hold basic user documentation for private preview feature documentation. For now the only page will be for the HPC Cache priming feature, but other products and features might use this space in the future. 

The page will be accessed directly by its URL, not linked from of any well-known existing page in this repository. This URL will be referenced by a redirect link that will be explicitly provided to preview participants and internal staff. When public preview begins, the material here will be moved to a first-level published docs.microsoft.com page.

I'm not sure if there's a risk of exposure by having the page here - it can be browsed to by anyone with access to the repository. It should not be indexed by search engines (is that still a thing?). 

For now this is a placeholder/test. Please comment if you have concerns.